### PR TITLE
fix: only count hard errors in stat_errors, not soft filesystem responses

### DIFF
--- a/src/ufsd#que.c
+++ b/src/ufsd#que.c
@@ -203,8 +203,19 @@ ufsd_dispatch(UFSD_ANCHOR *anchor, UFSREQ *req)
 
         if (rc == UFSD_RC_OK) {
             anchor->stat_requests++;
-        } else {
+        } else if (rc == UFSD_RC_IO      ||
+                   rc == UFSD_RC_NOSPACE ||
+                   rc == UFSD_RC_NOINODES||
+                   rc == UFSD_RC_CORRUPT ||
+                   rc == UFSD_RC_BADFUNC ||
+                   rc == UFSD_RC_BADSESS ||
+                   rc == UFSD_RC_INVALID) {
+            /* Hard errors only: I/O failures and protocol violations.
+            ** Soft filesystem responses (NOFILE, ISDIR, EXIST, etc.)
+            ** are normal outcomes and do not increment the error counter. */
             anchor->stat_errors++;
+        } else {
+            anchor->stat_requests++;
         }
 
         __xmpost(req->client_ascb, req->client_ecb_ptr, 0);


### PR DESCRIPTION
## Summary

- `UFSD_RC_NOFILE`, `UFSD_RC_ISDIR`, `UFSD_RC_NOTDIR`, `UFSD_RC_EXIST`, `UFSD_RC_NOTEMPTY`, `UFSD_RC_NAMETOOLONG` no longer increment `stat_errors`
- These are normal filesystem outcomes (ENOENT, EISDIR, etc.) — the server worked correctly
- Only hard errors (I/O failures, disk full, no inodes, corrupt structures, protocol violations) count as errors
- Soft responses still increment `stat_requests`, keeping the total accurate

Previously, a single HTTP page load requesting a missing resource (e.g. favicon.ico) showed `ERRORS: 1` in `/F UFSD,STATS`.

Closes #3

## Test plan

- [ ] Start UFSD, verify `ERRORS: 0`
- [ ] Request a non-existent file via FTP or HTTP
- [ ] `/F UFSD,STATS` — verify `ERRORS: 0`, `REQUESTS SERVED` incremented
- [ ] Trigger a real I/O error (if possible) — verify `ERRORS: 1`