### PR TITLE
fix: remove racf_get_acee() from SESS_OPEN in SSI router

### DIFF
--- a/src/ufsd#ses.c
+++ b/src/ufsd#ses.c
@@ -212,7 +212,7 @@ ufsd_sess_open(UFSD_ANCHOR *anchor, UFSREQ *req, unsigned *out_token)
     sess->flags        = UFSD_SESS_ACTIVE;
     sess->ufs          = (void *)ufs;
 
-    /* Copy client userid/group from SSI router (ACEE capture) */
+    /* Owner/group start empty — set by SETUSER after SESS_OPEN */
     memset(sess->owner, 0, sizeof(sess->owner));
     memset(sess->group, 0, sizeof(sess->group));
     if (req && req->data_len >= 18U) {

--- a/src/ufsd#ssi.c
+++ b/src/ufsd#ssi.c
@@ -40,7 +40,6 @@
 #include <clibssct.h>
 #include <iefssobh.h>
 #include <iefjssib.h>
-#include <racf.h>
 
 /* ============================================================
 ** Internal helpers (static, inline in the CSA load module)
@@ -249,26 +248,6 @@ ufsdssir(void)
     if (dlen > UFSREQ_MAX_INLINE) dlen = UFSREQ_MAX_INLINE;
     req->data_len = dlen;
     if (dlen > 0) memcpy(req->data, ufsssob->data, dlen);
-
-    /* SESS_OPEN: capture client userid/group from ACEE.
-    ** We are in the client's address space in key-0, so
-    ** racf_get_acee() returns the client's ACEE.
-    ** aceeuser/aceegrp are length-prefixed: byte 0 = len,
-    ** bytes 1..8 = name.  We strip the length byte and
-    ** store a plain NUL-terminated string. */
-    if (ufsssob->func == UFSREQ_SESS_OPEN) {
-        ACEE *acee = racf_get_acee();
-        if (acee) {
-            unsigned char ulen = (unsigned char)acee->aceeuser[0];
-            unsigned char glen = (unsigned char)acee->aceegrp[0];
-            if (ulen > 8) ulen = 8;
-            if (glen > 8) glen = 8;
-            memset(req->data, 0, 18);
-            memcpy(req->data,     acee->aceeuser + 1, ulen);
-            memcpy(req->data + 9, acee->aceegrp  + 1, glen);
-            req->data_len = 18;
-        }
-    }
 
     /* FWRITE 4K path: copy client buffer into CSA pool buffer.
     ** We are in key-0 in the client's address space, so we can


### PR DESCRIPTION
Fixes #10

## Summary

Remove the `racf_get_acee()` call from `ufsdssir` SESS_OPEN handling. ASXBSENV is per-address-space and shared across all HTTPD worker threads — concurrent `racf_login`/`racf_logout` creates a race condition causing S0C4 on stale ACEE pointers.

Session owner/group are now set exclusively via `UFSREQ_SETUSER` after SESS_OPEN. The client (mvsMF) already knows the authenticated user.

## Changes

- `src/ufsd#ssi.c`: removed ACEE capture block (lines 253-271) and `#include <racf.h>`
- `src/ufsd#ses.c`: updated comment to reflect new flow

## Test plan

- [ ] Build UFSD on MVS (`make build && make link`)
- [ ] Start UFSD + HTTPD, open multiple USS files via Zowe Explorer concurrently — no S0C4
- [ ] `/F UFSD,SESSIONS` shows empty owner/group after SESS_OPEN
- [ ] Verify SETUSER still populates owner/group correctly