### PR TITLE
fix: set last_rc in path-based operations (mkdir/rmdir/remove/chgdir)

### DIFF
--- a/client/libufs.c
+++ b/client/libufs.c
@@ -341,6 +341,7 @@ ufs_chgdir(UFS *ufs, const char *path)
     if (!ufs) return -1;
 
     rc = path_req(UFSREQ_CHGDIR, ufs->token, path);
+    ufs->last_rc = rc;
     if (rc == UFSD_RC_OK) {
         /* Mirror the new cwd in the local UFS handle */
         pathlen = strlen(path);
@@ -355,22 +356,31 @@ ufs_chgdir(UFS *ufs, const char *path)
 int
 ufs_mkdir(UFS *ufs, const char *path)
 {
+    int rc;
     if (!ufs) return -1;
-    return path_req(UFSREQ_MKDIR, ufs->token, path);
+    rc = path_req(UFSREQ_MKDIR, ufs->token, path);
+    ufs->last_rc = rc;
+    return rc;
 }
 
 int
 ufs_rmdir(UFS *ufs, const char *path)
 {
+    int rc;
     if (!ufs) return -1;
-    return path_req(UFSREQ_RMDIR, ufs->token, path);
+    rc = path_req(UFSREQ_RMDIR, ufs->token, path);
+    ufs->last_rc = rc;
+    return rc;
 }
 
 int
 ufs_remove(UFS *ufs, const char *path)
 {
+    int rc;
     if (!ufs) return -1;
-    return path_req(UFSREQ_REMOVE, ufs->token, path);
+    rc = path_req(UFSREQ_REMOVE, ufs->token, path);
+    ufs->last_rc = rc;
+    return rc;
 }
 
 /* ============================================================

--- a/client/libufstst.c
+++ b/client/libufstst.c
@@ -117,11 +117,11 @@ main(int argc, char **argv)
     ** Regression test for issue #8: must return NOFILE, not ROFS.
     ** ============================================================ */
     rc = ufs_mkdir(ufs, "/NO_SUCH_PARENT/SUBDIR");
-    if (rc == UFSD_RC_NOFILE) {
-        wtof("LUFTSTRFI MKDIR /NO_SUCH_PARENT/SUBDIR: NOFILE -- OK");
+    if (rc == UFSD_RC_NOFILE && ufs_last_rc(ufs) == UFSD_RC_NOFILE) {
+        wtof("LUFTSTRFI MKDIR /NO_SUCH.../SUBDIR: NOFILE (rc+last_rc) -- OK");
     } else {
-        wtof("LUFTSTRFE MKDIR /NO_SUCH_PARENT/SUBDIR: expected RC=%d, got RC=%d",
-             UFSD_RC_NOFILE, rc);
+        wtof("LUFTSTRFE MKDIR /NO_SUCH.../SUBDIR: rc=%d last_rc=%d (expected %d)",
+             rc, ufs_last_rc(ufs), UFSD_RC_NOFILE);
     }
 
     {
@@ -139,19 +139,19 @@ main(int argc, char **argv)
     }
 
     rc = ufs_remove(ufs, "/NO_SUCH_PARENT/FILE.TXT");
-    if (rc == UFSD_RC_NOFILE) {
-        wtof("LUFTSTRFI REMOVE /NO_SUCH.../FILE.TXT: NOFILE -- OK");
+    if (rc == UFSD_RC_NOFILE && ufs_last_rc(ufs) == UFSD_RC_NOFILE) {
+        wtof("LUFTSTRFI REMOVE /NO_SUCH.../FILE.TXT: NOFILE (rc+last_rc) -- OK");
     } else {
-        wtof("LUFTSTRFE REMOVE /NO_SUCH.../FILE.TXT: expected RC=%d, got RC=%d",
-             UFSD_RC_NOFILE, rc);
+        wtof("LUFTSTRFE REMOVE /NO_SUCH.../FILE.TXT: rc=%d last_rc=%d (expected %d)",
+             rc, ufs_last_rc(ufs), UFSD_RC_NOFILE);
     }
 
     rc = ufs_rmdir(ufs, "/NO_SUCH_PARENT/SUBDIR");
-    if (rc == UFSD_RC_NOFILE) {
-        wtof("LUFTSTRFI RMDIR /NO_SUCH.../SUBDIR: NOFILE -- OK");
+    if (rc == UFSD_RC_NOFILE && ufs_last_rc(ufs) == UFSD_RC_NOFILE) {
+        wtof("LUFTSTRFI RMDIR /NO_SUCH.../SUBDIR: NOFILE (rc+last_rc) -- OK");
     } else {
-        wtof("LUFTSTRFE RMDIR /NO_SUCH.../SUBDIR: expected RC=%d, got RC=%d",
-             UFSD_RC_NOFILE, rc);
+        wtof("LUFTSTRFE RMDIR /NO_SUCH.../SUBDIR: rc=%d last_rc=%d (expected %d)",
+             rc, ufs_last_rc(ufs), UFSD_RC_NOFILE);
     }
 
     /* ============================================================
@@ -159,11 +159,11 @@ main(int argc, char **argv)
     ** Root "/" is read-only, so writing there must return ROFS.
     ** ============================================================ */
     rc = ufs_mkdir(ufs, "/ROFS_TEST_DIR");
-    if (rc == UFSD_RC_ROFS) {
-        wtof("LUFTSTRFI MKDIR /ROFS_TEST_DIR: ROFS -- OK");
+    if (rc == UFSD_RC_ROFS && ufs_last_rc(ufs) == UFSD_RC_ROFS) {
+        wtof("LUFTSTRFI MKDIR /ROFS_TEST_DIR: ROFS (rc+last_rc) -- OK");
     } else {
-        wtof("LUFTSTRFE MKDIR /ROFS_TEST_DIR: expected RC=%d, got RC=%d",
-             UFSD_RC_ROFS, rc);
+        wtof("LUFTSTRFE MKDIR /ROFS_TEST_DIR: rc=%d last_rc=%d (expected %d)",
+             rc, ufs_last_rc(ufs), UFSD_RC_ROFS);
     }
 
     /* ============================================================


### PR DESCRIPTION
## Summary

- `ufs_mkdir()`, `ufs_rmdir()`, `ufs_remove()`, and `ufs_chgdir()` now set `ufs->last_rc` after every call
- Previously, `ufs_last_rc()` was stale after these operations, making error handling unreliable for consumers

## Root cause

All four functions used the internal `path_req()` helper which has no access to the `UFS *` handle. The return code was correctly propagated as the function return value, but `ufs->last_rc` was never updated — so `ufs_last_rc(ufs)` returned a stale value from a previous operation.

## Test updates

LIBUFSTST regression tests now verify both `rc` and `ufs_last_rc()` for:
- NOFILE scenarios (non-existent paths)
- ROFS scenarios (valid paths on read-only mounts)

## Test plan

- [ ] `make build && make link` — all RC=0
- [ ] Run LIBUFTST on MVS — all LUFTSTRFI lines should show `(rc+last_rc) -- OK`

Fixes #9