### PR TITLE
docs: AP-4a housekeeping — concept.md and CLAUDE.md update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,10 @@ Derived from [ufs370](https://github.com/mvslovers/ufs370). Runs on Hercules.
 
 ## Current Status
 
-**Post-PoC Hardening — AP-2a**  
-Phase 1 (AP-1a–1f) complete. HTTPD and FTPD operational via libufsd.  
-Current focus: FWRITE 4K path, timestamps, POST-Bündelung, write-behind buffer.
+**Operational — AP-4a complete**
+Phases 1–3 (AP-1a–3b) complete. AP-4a hardening done: SSI timed WAIT,
+superblock writeback, logging cleanup, session prune, test consolidation.
+HTTPD and FTPD operational via libufs.
 
 ## Architecture in 30 Seconds
 

--- a/doc/concept.md
+++ b/doc/concept.md
@@ -2,11 +2,22 @@
 
 Cross-Address-Space Filesystem Server for MVS 3.8j
 Repository: github.com/mvslovers/ufsd
-Revision 7 — Reflects completed Phase 3 (AP-3a + AP-3b)
+Revision 8 — Reflects completed Phase 4a (AP-4a)
 
 ---
 
-## Changes from Concept #6
+## Changes from Concept #7
+
+| # | Area | Change |
+|---|------|--------|
+| 1 | SSI timed WAIT | Unconditional WAIT replaced with `ecb_timed_wait` loop (5 s interval). Checks `UFSD_ANCHOR_ACTIVE` after each timeout; returns `UFSD_RC_CORRUPT` if server is dead. Prevents client hangs (AP-4a #2). |
+| 2 | Superblock writeback | `ufsd_ufs_term` and `ufsd_disk_umount` call `ufsd_sb_write` for each RW disk before closing. Persists free block/inode caches (AP-4a #3). |
+| 3 | Logging cleanup | All WTO messages follow `UFSDnnnS` pattern. `UFSD-DBG` messages removed. UFSDCLNP messages assigned 140-149 range. Message number conflicts resolved across modules (AP-4a #5). |
+| 4 | Startup banner | `UFSD000I` before init, `UFSD001I` with version, disk count, CSA size, session/file slot summary (AP-4a #5). |
+| 5 | Session cleanup | `SESSIONS PRUNE` command walks ASVT, detects terminated ASIDs, releases orphaned sessions with FDs and GFT entries (AP-4a #6). |
+| 6 | Test consolidation | Removed `ufsdping` (superseded by `/F UFSD,STATS`) and `ufsdtst` (superseded by `LIBUFTST`). `LIBUFTST` retained as sole regression tool (AP-4a #7). |
+
+<details><summary>Changes from Concept #6 (AP-3a + AP-3b)</summary>
 
 | # | Area | Change |
 |---|------|--------|
@@ -24,6 +35,8 @@ Revision 7 — Reflects completed Phase 3 (AP-3a + AP-3b)
 | 12 | `ufs_sys_term` | Signature changed to `(UFSSYS **)`, frees the calloc'd UFSSYS block (AP-3b). |
 | 13 | `mkdir_p` cleanup | Owner/group strings use `strcpy` instead of `memcpy` with trailing blanks (AP-3b). |
 | 14 | Comment fixes | DIRREAD_RLEN corrected to 98 bytes; dispatch comment updated for `__xmpost` (AP-3b). |
+
+</details>
 
 ---
 
@@ -51,9 +64,9 @@ UFSD solves this by running the filesystem as a Subsystem Started Task (STC) wit
 │  SSI Router           │     │                          │
 │  (ufsd#ssi)           │     │  Session Table (64 slots)│
 │    │ R1=SSOB          │     │    ├─ fd_table[64]       │
-│    │ ACEE capture     │     │    ├─ CWD                │
-│    │ __xmpost to wake │     │    └─ owner/group        │
-│    │ WAIT on stack ECB│     │  Global File Table (256) │
+│    │ __xmpost to wake │     │    ├─ CWD                │
+│    │ timed WAIT (5s)  │     │    └─ owner/group        │
+│    │ liveness check   │     │  Global File Table (256) │
 │    ▼                  │     │  MODIFY commands         │
 │  ┌─────── CSA ────────────────────────────────┐       │
 │  │  UFSD_ANCHOR                               │       │


### PR DESCRIPTION
## Summary
- Bump `doc/concept.md` to Revision 8 with AP-4a change log
- Fold AP-3a/3b changes into a collapsible `<details>` section
- Fix architecture diagram: remove stale "ACEE capture", add "timed WAIT / liveness check"
- Update CLAUDE.md current status to "Operational — AP-4a complete"

Note: `doc/AP-3b.md` → `doc/completed/` was already done in PR #16.

Fixes #28

## Test plan
- [ ] Verify concept.md renders correctly on GitHub (collapsible section)