### PR TITLE
Restore APF AC(1) on the UFSD load module

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -11,6 +11,7 @@ cflags = ["-I", "include"]
 [[module]]
 name = "UFSD"
 startup = "crt1"
+ac = 1
 sources = ["src/ufsd*.c"]
 exclude = ["src/ufsdclnp.c", "src/ufsd#ssi.c"]
 


### PR DESCRIPTION
UFSD is an APF-authorized STC; the v2 migration dropped the v1 setcode AC(1). Set ac = 1 on UFSD and bump mbt to the build that wires module 'ac' to ld370 --ac. Verified: UFSD AC=01, UFSDSSIR/UFSDCLNP AC=00.

Closes #34