### PR TITLE
Quiesce SSI clients + null SSVT entry before freeing CSA (fix #30 S0C4)

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -6,11 +6,11 @@ This document covers UFSD recovery procedures, the emergency cleanup utility, an
 
 Stop the daemon with `/P UFSD` or `/F UFSD,SHUTDOWN`. UFSD performs an orderly shutdown:
 
-1. Writes superblocks back to disk for all RW-mounted filesystems
-2. Closes all BDAM datasets (DYNFREE)
-3. Deregisters the SSCT from the subsystem chain
-4. Unloads the SSI router (UFSDSSIR) from CSA
-5. Frees all CSA pools (requests, buffers, trace, anchor)
+1. Nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` (no new SSI dispatches; parked clients bail on their next timeout)
+2. Writes superblocks back to disk for all RW-mounted filesystems and closes all BDAM datasets (DYNFREE)
+3. Drains in-flight SSI clients — waits for `anchor->inflight` to reach zero (~10 s ceiling); on timeout it retains the CSA and issues `UFSD098W`
+4. Deregisters the SSCT (freeing the SSVT) and unloads the SSI router (UFSDSSIR) from CSA
+5. Frees all CSA pools (requests, buffers, trace) and the anchor
 
 Console output:
 
@@ -23,7 +23,7 @@ UFSD099I UFSD shutdown complete
 
 ## Recovery after Abend
 
-If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler attempts an emergency shutdown. However, the ESTAE may not fully deregister all resources (see [Known Issues](#known-issues)). In that case, SSCT, SSI router, and CSA pools remain allocated.
+If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler runs in emergency mode (`UFSD_SHUT_ABEND`): it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` — stopping new SSI dispatches and letting parked clients bail — then percolates for the MVS dump. It deliberately frees **nothing**: under RTM there is no reliable way to tell whether another address space is still executing inside the router module or the CSA pools, and freeing them then is exactly the S0C4 being recovered from. SSCT, SSI router, and CSA pools are therefore left allocated and reclaimed by UFSDCLNP on the next start — this is by design, not a defect (see [CSA Retained after /C or Abend](#csa-retained-after-c-cancel-or-abend-by-design)).
 
 **Symptoms of stale resources:**
 
@@ -79,11 +79,15 @@ Copy the UFSDCLNP STC procedure from `samplib/ufsdclnp` to `SYS2.PROCLIB(UFSDCLN
 
 ## Known Issues
 
-### ESTAE Handler Incomplete after /C CANCEL (TSK-71)
+### CSA Retained after /C CANCEL or Abend (by design)
 
-After `/C UFSD`, the ESTAE handler intercepts the S222 abend and reports "UFSD shutdown complete". However, UFSDCLNP still finds resources allocated (SSCT registered, SSI loaded, CSA present). The ESTAE handler may be failing to complete some cleanup steps during abend processing.
+After `/C UFSD` or any abend, the ESTAE handler runs in `UFSD_SHUT_ABEND` mode: it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` (so `iefssreq` stops routing new clients into UFSDSSIR and any parked client bails on its next router timeout), then percolates. It **frees nothing** — under RTM a foreign PSW may still be executing inside the router module or touching the CSA pools, and freeing them then is the very S0C4 this behaviour prevents.
 
-**Workaround:** Always run `/S UFSDCLNP` after `/C UFSD` before restarting.
+So `/S UFSDCLNP` is the **designed** recovery step after `/C` or an abend, not a workaround. UFSDCLNP nulls the SSVT entry (idempotent), deregisters the SSCT, and frees the router module, pools, and anchor. Because `ufsd_anchor_free`/UFSDCLNP invalidate the anchor eye catcher before the FREEMAIN, a client still looping in the router revalidates it on its next timeout and bails with `RC_CORRUPT` — a stuck HTTPD/FTPD worker does not hang indefinitely (worst case one `UFSD_WAIT_INTERVAL`, ~5 s).
+
+A clean `/P UFSD` (or `/F UFSD,SHUTDOWN`) runs in `UFSD_SHUT_NORMAL` mode instead: it nulls the SSVT entry, clears `UFSD_ANCHOR_ACTIVE`, then **drains** `anchor->inflight` to zero and frees the CSA itself — no UFSDCLNP needed after a normal stop. If the drain does not reach zero within its ceiling (~10 s), UFSD issues `UFSD098W` and retains the CSA rather than freeing storage a client may still be executing; run `/S UFSDCLNP` in that case.
+
+**TSK-71** (ESTAE handler "incomplete" after `/C`) is closed by this: the retained CSA is intended, and UFSDCLNP is the supported recovery path.
 
 ### No Per-File Permission System
 
@@ -116,7 +120,11 @@ All UFSD messages follow the `UFSDnnnS` pattern, where `nnn` is the message numb
 | UFSD090I | I | Shutdown initiated |
 | UFSD091I | I | Superblock written for disk |
 | UFSD092I | I | Filesystems unmounted |
+| UFSD096I | I | CSA freed |
+| UFSD097E | E | Cannot enter supervisor state at shutdown — CSA retained, run UFSDCLNP |
+| UFSD097W | W | Abend shutdown — CSA retained, run UFSDCLNP before restart |
 | UFSD098E | E | Abend intercepted — emergency shutdown |
+| UFSD098W | W | Client(s) still in flight at shutdown — CSA retained, run UFSDCLNP |
 | UFSD099I | I | Shutdown complete |
 
 ### Configuration and Mounts (060–079, 120–129)
@@ -148,6 +156,7 @@ All UFSD messages follow the `UFSDnnnS` pattern, where `nnn` is the message numb
 | UFSD143I | I | SSI router module freed |
 | UFSD144I | I | CSA pools freed |
 | UFSD145I | I | Anchor freed |
+| UFSD146W | W | Clients were in flight when UFSD died (diagnostic) |
 | UFSD149I | I | UFSDCLNP complete |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -298,6 +298,15 @@ struct ufsd_anchor {
 
     /* AP-1e: STC pointer (for file dispatch access to stc->disks[]) */
     void           *server_stc;     /* UFSD_STC *, set at startup            */
+
+    /* Issue #30: count of SSI clients currently executing inside
+    ** ufsdssir.  Incremented (CS, key-0) right after free_pop() at
+    ** router entry, decremented before every router return.  Shutdown
+    ** clears UFSD_ANCHOR_ACTIVE, then drains this to zero before it
+    ** frees any CSA.  Appended at the end of the anchor so the field
+    ** offsets shared with UFSDSSIR/UFSDCLNP are unchanged -- but all
+    ** three load modules must still be rebuilt and deployed together. */
+    unsigned        inflight;
 };
 
 /* ============================================================
@@ -511,10 +520,22 @@ struct ufsssob {
 int  ufsd_process_cib(UFSD_STC *ufsd, CIB *cib);
 
 /* ufsd.c (AP-1a) */
-/* graceful != 0: clean STOP -- quiesce in-flight SSI clients (clear
-** UFSD_ANCHOR_ACTIVE + grace WAIT) before freeing shared CSA.
-** graceful == 0: emergency/ESTAE path -- clear the flag but do not WAIT. */
-void ufsd_shutdown(UFSD_STC *ufsd, int graceful);
+/* Shutdown modes for ufsd_shutdown().
+**
+** UFSD_SHUT_NORMAL  clean STOP (/P, SHUTDOWN) or startup failure:
+**                   null SSVT entry, clear ANCHOR_ACTIVE, drain
+**                   in-flight clients, then release CSA.
+** UFSD_SHUT_ABEND   ESTAE recovery path: null SSVT entry and clear
+**                   ANCHOR_ACTIVE only.  No drain (STIMER under RTM
+**                   is unsafe) and no CSA release -- the state of
+**                   in-flight clients is unknown, and freeing CSA
+**                   that a foreign PSW may be executing is exactly
+**                   the S0C4 this fix is meant to prevent.
+**                   UFSDCLNP reclaims on the next start. */
+#define UFSD_SHUT_NORMAL  0
+#define UFSD_SHUT_ABEND   1
+
+void ufsd_shutdown(UFSD_STC *ufsd, int mode);
 
 /* ufsd#csa.c (AP-1b) */
 UFSD_ANCHOR *ufsd_anchor_alloc(void)                                 asm("UFSD@ANA");

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -511,7 +511,10 @@ struct ufsssob {
 int  ufsd_process_cib(UFSD_STC *ufsd, CIB *cib);
 
 /* ufsd.c (AP-1a) */
-void ufsd_shutdown(UFSD_STC *ufsd);
+/* graceful != 0: clean STOP -- quiesce in-flight SSI clients (clear
+** UFSD_ANCHOR_ACTIVE + grace WAIT) before freeing shared CSA.
+** graceful == 0: emergency/ESTAE path -- clear the flag but do not WAIT. */
+void ufsd_shutdown(UFSD_STC *ufsd, int graceful);
 
 /* ufsd#csa.c (AP-1b) */
 UFSD_ANCHOR *ufsd_anchor_alloc(void)                                 asm("UFSD@ANA");

--- a/src/ufsd#csa.c
+++ b/src/ufsd#csa.c
@@ -47,6 +47,11 @@ ufsd_anchor_free(UFSD_ANCHOR *anchor)
 
     if (!anchor) return;
     if (__super(PSWKEY0, &savekey)) return;
+    /* Invalidate the eye catcher BEFORE releasing the block.  Freed
+    ** SP=241 storage is reused, not zeroed, so a client still looping
+    ** in ufsdssir must not accept the reused anchor as valid: its
+    ** timeout-branch revalidates "UFSDANCR" and bails once it is gone. */
+    memset(anchor->eye, 0, sizeof(anchor->eye));
     freemain(anchor);
     __prob(savekey, NULL);
 }

--- a/src/ufsd#ssi.c
+++ b/src/ufsd#ssi.c
@@ -237,6 +237,12 @@ ufsdssir(void)
         return;
     }
 
+    /* Mark ourselves in-flight.  Shutdown clears UFSD_ANCHOR_ACTIVE and
+    ** then drains this counter to zero before it frees the router and
+    ** pools.  Incremented here (still inside the entry key-0 window) and
+    ** decremented on every path out of the router below. */
+    __uinc(&anchor->inflight);
+
     /* --- Fill in the request block --- */
     local_ecb           = 0;             /* clear before storing pointer          */
     req->client_ecb_ptr = &local_ecb;    /* key-8 stack ECB, WAIT target          */
@@ -318,12 +324,35 @@ ufsdssir(void)
             if ((*ecbp & ECB_VALUE_MASK) != UFSD_TIMEOUT_CODE)
                 break;
 
-            /* Timeout: check if server is still alive */
-            if (!(anchor->flags & UFSD_ANCHOR_ACTIVE)) {
-                /* Server is dead.  The request block is orphaned in CSA;
-                ** UFSDCLNP will reclaim it on the next start. */
-                ssob->SSOBRETN = UFSD_RC_CORRUPT;
-                return;
+            /* Timeout: is the server still there?
+            **
+            ** Freed CSA (SP=241) is reused, not zeroed, so anchor->flags
+            ** alone cannot be trusted after an emergency shutdown -- a
+            ** stale high bit would keep us looping forever on an ECB
+            ** nobody will ever post.  Revalidate the eye catcher first. */
+            {
+                int eye_ok = (memcmp(anchor->eye, "UFSDANCR", 8) == 0);
+
+                if (!eye_ok || !(anchor->flags & UFSD_ANCHOR_ACTIVE)) {
+                    /* Server gone or quiescing.  If the anchor is still
+                    ** valid (a clean shutdown retains it), give back our
+                    ** in-flight count so ufsd_drain() can complete -- open a
+                    ** dedicated key-0 window, since we are in problem state
+                    ** here.  If the eye catcher is gone the anchor was
+                    ** already freed (emergency path / UFSDCLNP): the counter
+                    ** no longer exists, so do NOT write to it.  The request
+                    ** block stays orphaned; the STC may still hold it on its
+                    ** queue. */
+                    if (eye_ok) {
+                        unsigned char bkey;
+                        if (!__super(PSWKEY0, &bkey)) {
+                            __udec(&anchor->inflight);
+                            __prob(bkey, NULL);
+                        }
+                    }
+                    ssob->SSOBRETN = UFSD_RC_CORRUPT;
+                    return;
+                }
             }
 
             /* Server alive but hasn't replied yet.  Clear ECB, retry. */
@@ -387,6 +416,21 @@ ufsdssir(void)
             __uinc(&anchor->free_count);
         }
 
+        /* Leave the router: decrement inflight LAST, so a shutdown drain
+        ** only observes us gone after every other CSA write is complete. */
+        __udec(&anchor->inflight);
+
         __prob(savekey, NULL);
+    } else {
+        /* Re-entering supervisor state failed here (it succeeded at entry,
+        ** so this should be impossible).  We cannot copy results or return
+        ** the request block, but we still owe the inflight decrement so a
+        ** shutdown drain can finish -- retry a minimal key-0 window for it.
+        ** The request block stays orphaned (reclaimed with the pool). */
+        if (!__super(PSWKEY0, &savekey)) {
+            __udec(&anchor->inflight);
+            __prob(savekey, NULL);
+        }
+        ssob->SSOBRETN = UFSD_RC_CORRUPT;
     }
 }

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -24,6 +24,10 @@
 **     SSI router unloaded) then percolates for normal MVS dump
 **   - ufsd_shutdown() deletes the ESTAE as its first action to
 **     prevent re-entrant recovery on clean or emergency shutdown
+**   - ufsd_shutdown() clears UFSD_ANCHOR_ACTIVE so in-flight SSI
+**     clients quiesce out of the CSA router/pools before they are
+**     freed; the clean STOP path also waits one router interval
+**     (Issue #30 -- intermittent S0C4 in the shutdown FREEMAIN path)
 */
 
 #ifndef VERSION
@@ -68,7 +72,7 @@ ufsd_recover(SDWA *sdwa)
 
     if (ufsd) {
         ufsd->flags &= ~UFSD_ACTIVE;
-        ufsd_shutdown(ufsd);
+        ufsd_shutdown(ufsd, 0);   /* emergency: clear flag, no grace WAIT */
     }
 
     /* Percolate: let MVS produce the abend dump and terminate */
@@ -76,7 +80,7 @@ ufsd_recover(SDWA *sdwa)
 }
 
 void
-ufsd_shutdown(UFSD_STC *ufsd)
+ufsd_shutdown(UFSD_STC *ufsd, int graceful)
 {
     UFSD_ANCHOR *anchor;
 
@@ -85,6 +89,32 @@ ufsd_shutdown(UFSD_STC *ufsd)
     __estae(ESTAE_DELETE, NULL, NULL);
 
     anchor = ufsd->anchor;
+
+    /* Quiesce in-flight SSI clients BEFORE freeing any shared CSA.
+    ** ufsdssir runs in the *client's* address space out of the CSA load
+    ** module and spins in a timed WAIT (UFSD_WAIT_INTERVAL = 5 s),
+    ** re-checking UFSD_ANCHOR_ACTIVE after every timeout.  We clear that
+    ** flag so a waiting client bails out of the module and the request/
+    ** buffer pools before ufsd_ssi_unload()/ufsd_csa_free() freemain them
+    ** underneath it.  (Issue #30: tearing down the router + pools while a
+    ** client was still in-flight corrupted CSA and abended the shutdown
+    ** FREEMAIN path with an intermittent S0C4.) */
+    if (anchor) {
+        unsigned char savekey;
+        if (!__super(PSWKEY0, &savekey)) {
+            anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
+            __prob(savekey, NULL);
+        }
+        /* Clean STOP only: wait one router interval (+1 s margin) so every
+        ** waiting client gets at least one timeout to observe the cleared
+        ** flag and return.  Skipped on the emergency/ESTAE path
+        ** (graceful == 0), where a STIMER WAIT under RTM is unsafe -- there
+        ** we percolate and let UFSDCLNP reclaim any orphaned block on the
+        ** next start. */
+        if (graceful) {
+            __asm__ __volatile__("STIMER WAIT,BINTVL==F'600'");  /* 6.00 s */
+        }
+    }
 
     /* AP-1d Step 2: close disk datasets (STC-local, before CSA free) */
     ufsd_ufs_term(ufsd);
@@ -245,7 +275,7 @@ main(int argc, char **argv)
     /* --- UFS disk init (AP-1d Step 2) ----------------------------- */
     rc = ufsd_ufs_init(&ufsd);
     if (rc != 0) {
-        ufsd_shutdown(&ufsd);
+        ufsd_shutdown(&ufsd, 0);  /* startup failure: no clients yet */
         return 8;
     }
 
@@ -330,6 +360,6 @@ main(int argc, char **argv)
         }
     }
 
-    ufsd_shutdown(&ufsd);
+    ufsd_shutdown(&ufsd, 1);      /* clean STOP: quiesce in-flight clients */
     return 0;
 }

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -20,14 +20,21 @@
 **
 ** ESTAE recovery (AP-1d+):
 **   - ufsd_recover() registered immediately after APF setup
-**   - Any abend triggers emergency shutdown (SSCT deregistered,
-**     SSI router unloaded) then percolates for normal MVS dump
 **   - ufsd_shutdown() deletes the ESTAE as its first action to
 **     prevent re-entrant recovery on clean or emergency shutdown
-**   - ufsd_shutdown() clears UFSD_ANCHOR_ACTIVE so in-flight SSI
-**     clients quiesce out of the CSA router/pools before they are
-**     freed; the clean STOP path also waits one router interval
-**     (Issue #30 -- intermittent S0C4 in the shutdown FREEMAIN path)
+**
+** Shutdown quiescing (Issue #30):
+**   ufsd_shutdown() nulls the SSVT function entry and clears
+**   UFSD_ANCHOR_ACTIVE FIRST, so iefssreq stops routing new clients
+**   into UFSDSSIR and parked clients bail on their next timeout.
+**   - UFSD_SHUT_NORMAL (clean STOP / startup fail): then drains the
+**     anchor->inflight counter to zero and releases the CSA.  A drain
+**     timeout retains CSA rather than freeing storage a client may
+**     still be executing.
+**   - UFSD_SHUT_ABEND (ESTAE): nulls the entry + clears the flag only,
+**     then percolates for the MVS dump.  Under RTM the state of
+**     in-flight clients is unknown, so nothing is freed.  UFSDCLNP
+**     reclaims the CSA on the next start.
 */
 
 #ifndef VERSION
@@ -47,9 +54,12 @@
 ** in the UFSD STC address space.
 **
 ** Goals:
-**   1. Deregister the SSCT + unload UFSDSSIR so that MVS can
-**      route future SSI calls to another handler (or reject them
-**      cleanly) rather than crashing in a dangling SSVT entry.
+**   1. Null the SSVT function entry + clear UFSD_ANCHOR_ACTIVE
+**      (UFSD_SHUT_ABEND) so iefssreq stops dispatching new clients
+**      into UFSDSSIR and parked clients bail on their next timeout.
+**      CSA is NOT freed: under RTM a foreign PSW may still be inside
+**      the router or the pools, and freeing it is the very S0C4 we
+**      are recovering from.  UFSDCLNP reclaims the CSA on next start.
 **   2. Percolate (SDWACWT = 0): MVS produces the SVC dump and
 **      terminates the address space normally.
 **
@@ -72,79 +82,147 @@ ufsd_recover(SDWA *sdwa)
 
     if (ufsd) {
         ufsd->flags &= ~UFSD_ACTIVE;
-        ufsd_shutdown(ufsd, 0);   /* emergency: clear flag, no grace WAIT */
+        ufsd_shutdown(ufsd, UFSD_SHUT_ABEND);
     }
 
     /* Percolate: let MVS produce the abend dump and terminate */
     sdwa->SDWARCDE = SDWACWT;
 }
 
-void
-ufsd_shutdown(UFSD_STC *ufsd, int graceful)
+/* ufsd_pause -- block the STC for `hsec` hundredths of a second.
+**
+** Uses ecb_timed_wait() on a private stack ECB that nobody posts: the
+** interval timer fires after `hsec` hundredths, posts the ECB, and wakes
+** us.  This is the same timed-wait primitive the SSI router (5 s liveness
+** wait) and libc370 sleep() use, so its runtime behaviour is already
+** proven on this target -- preferred over a hand-rolled STIMER WAIT,
+** BINTVL whose operand form and unit would be unverified here.  It is
+** also a call barrier, so ufsd_drain()'s poll of anchor->inflight is
+** reloaded across it. */
+static void
+ufsd_pause(unsigned hsec)
 {
-    UFSD_ANCHOR *anchor;
+    ECB local = 0;
+    ecb_timed_wait(&local, hsec, 0);
+}
+
+/* ufsd_drain -- poll anchor->inflight to zero.  Returns 1 on success,
+** 0 on timeout.
+**
+** With no clients in flight this returns after one settle -- a clean /P
+** costs a fraction of a second.  A client parked in ecb_timed_wait needs
+** up to one full UFSD_WAIT_INTERVAL (5.00 s) to notice the cleared
+** ANCHOR_ACTIVE flag, so the ceiling exceeds that.
+**
+** The counter tracks CSA *data* access; a client that has just
+** decremented is still executing the router epilogue out of the CSA load
+** module, so a short settle is added and inflight re-checked.  Neither is
+** a guarantee -- which is why a drain timeout means "retain CSA", not
+** "free anyway".  anchor->inflight is in CSA without fetch-protection and
+** is read from problem state (volatile: another address space writes it;
+** no __super needed to poll). */
+#define UFSD_DRAIN_POLL     10U   /* 0.10 s per poll                     */
+#define UFSD_DRAIN_MAX     100U   /* 100 * 0.10 s = 10.00 s ceiling      */
+#define UFSD_DRAIN_SETTLE   20U   /* 0.20 s after inflight reaches zero  */
+
+static int
+ufsd_drain(UFSD_ANCHOR *anchor)
+{
+    volatile unsigned *inflight = &anchor->inflight;
+    unsigned           n;
+
+    for (n = 0; n < UFSD_DRAIN_MAX; n++) {
+        if (*inflight == 0) {
+            ufsd_pause(UFSD_DRAIN_SETTLE);
+            return (*inflight == 0);      /* re-check: catch a racing entry */
+        }
+        ufsd_pause(UFSD_DRAIN_POLL);
+    }
+    return 0;
+}
+
+void
+ufsd_shutdown(UFSD_STC *ufsd, int mode)
+{
+    UFSD_ANCHOR   *anchor;
+    unsigned char  savekey;
 
     /* Delete ESTAE first: prevents re-entrant recovery if shutdown
-    ** itself encounters an error (clean path or emergency path). */
+    ** itself encounters an error. */
     __estae(ESTAE_DELETE, NULL, NULL);
 
     anchor = ufsd->anchor;
 
-    /* Quiesce in-flight SSI clients BEFORE freeing any shared CSA.
-    ** ufsdssir runs in the *client's* address space out of the CSA load
-    ** module and spins in a timed WAIT (UFSD_WAIT_INTERVAL = 5 s),
-    ** re-checking UFSD_ANCHOR_ACTIVE after every timeout.  We clear that
-    ** flag so a waiting client bails out of the module and the request/
-    ** buffer pools before ufsd_ssi_unload()/ufsd_csa_free() freemain them
-    ** underneath it.  (Issue #30: tearing down the router + pools while a
-    ** client was still in-flight corrupted CSA and abended the shutdown
-    ** FREEMAIN path with an intermittent S0C4.) */
     if (anchor) {
-        unsigned char savekey;
-        if (!__super(PSWKEY0, &savekey)) {
-            anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
-            __prob(savekey, NULL);
+        /* --- Step 1: close the door -------------------------------
+        ** Null the SSVT function entry BEFORE anything is freed.  Until
+        ** this store, iefssreq keeps routing new clients into UFSDSSIR --
+        ** including into the entry checks themselves, which are
+        ** instructions inside the very module we are about to FREEMAIN.
+        ** Clearing ANCHOR_ACTIVE alone does not stop that; only the SSVT
+        ** entry does.  Same order as UFSDCLNP. */
+        if (__super(PSWKEY0, &savekey)) {
+            wtof("UFSD097E Cannot enter supervisor state -- "
+                 "CSA retained, run UFSDCLNP before restart");
+            ufsd_ufs_term(ufsd);
+            return;                       /* free nothing */
         }
-        /* Clean STOP only: wait one router interval (+1 s margin) so every
-        ** waiting client gets at least one timeout to observe the cleared
-        ** flag and return.  Skipped on the emergency/ESTAE path
-        ** (graceful == 0), where a STIMER WAIT under RTM is unsafe -- there
-        ** we percolate and let UFSDCLNP reclaim any orphaned block on the
-        ** next start. */
-        if (graceful) {
-            __asm__ __volatile__("STIMER WAIT,BINTVL==F'600'");  /* 6.00 s */
+        if (anchor->ssvt) {
+            ssvt_reset(anchor->ssvt, UFSD_SSVT_ROUTER);
+            ssvt_funcmap(anchor->ssvt, 0, UFSD_SSOBFUNC);
         }
+        /* Step 2: parked clients bail on their next timeout. */
+        anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
+        __prob(savekey, NULL);
     }
 
-    /* AP-1d Step 2: close disk datasets (STC-local, before CSA free) */
+    /* Step 3: close disk datasets (STC-local, superblock writeback). */
     ufsd_ufs_term(ufsd);
 
-    if (anchor) {
-        /* AP-1c: deregister + unload SSI router first */
-        if (anchor->ssir_lpa) {
-            ufsd_ssi_unload(anchor);
-            wtof("UFSD036I SSI router unloaded");
-        }
-        if (anchor->ssct) {
-            ufsd_ssct_free(anchor);
-            wtof("UFSD095I SSCT deregistered");
-        }
-        /* AP-1e: release GFT before session table */
-        if (anchor->gfiles) {
-            ufsd_gft_free(anchor);
-            wtof("UFSD048I Global file table freed");
-        }
-        /* AP-1d: release session table before freeing CSA */
-        if (anchor->sessions) {
-            ufsd_sess_free(anchor);
-            wtof("UFSD046I Session table freed");
-        }
-        ufsd_csa_free(anchor);
-        wtof("UFSD096I CSA freed");
-        ufsd_anchor_free(anchor);
-        ufsd->anchor = NULL;
+    if (!anchor)
+        goto done;
+
+    if (mode == UFSD_SHUT_ABEND) {
+        /* Under RTM we cannot drain and must not free: a foreign PSW may
+        ** still be executing inside UFSDSSIR or touching the pools.
+        ** Leave everything and percolate; UFSDCLNP reclaims on restart. */
+        wtof("UFSD097W Abend shutdown -- CSA retained, "
+             "run UFSDCLNP before restart");
+        goto done;
     }
 
+    /* Step 4: drain in-flight clients out of the router. */
+    if (!ufsd_drain(anchor)) {
+        wtof("UFSD098W %u client(s) still in flight -- CSA retained, "
+             "run UFSDCLNP before restart", anchor->inflight);
+        goto done;                        /* free nothing */
+    }
+
+    /* Step 5..9: teardown, same order as UFSDCLNP -- deregister the SSCT
+    ** (which also frees the SSVT), unload the router module, then release
+    ** the tables, pools, and finally the anchor. */
+    if (anchor->ssct) {
+        ufsd_ssct_free(anchor);
+        wtof("UFSD095I SSCT deregistered");
+    }
+    if (anchor->ssir_lpa) {
+        ufsd_ssi_unload(anchor);
+        wtof("UFSD036I SSI router unloaded");
+    }
+    if (anchor->gfiles) {
+        ufsd_gft_free(anchor);
+        wtof("UFSD048I Global file table freed");
+    }
+    if (anchor->sessions) {
+        ufsd_sess_free(anchor);
+        wtof("UFSD046I Session table freed");
+    }
+    ufsd_csa_free(anchor);
+    wtof("UFSD096I CSA freed");
+    ufsd_anchor_free(anchor);             /* clears the eye catcher first */
+    ufsd->anchor = NULL;
+
+done:
     wtof("UFSD099I UFSD shutdown complete");
 }
 
@@ -275,7 +353,8 @@ main(int argc, char **argv)
     /* --- UFS disk init (AP-1d Step 2) ----------------------------- */
     rc = ufsd_ufs_init(&ufsd);
     if (rc != 0) {
-        ufsd_shutdown(&ufsd, 0);  /* startup failure: no clients yet */
+        /* No clients yet: drain sees inflight == 0 and returns at once. */
+        ufsd_shutdown(&ufsd, UFSD_SHUT_NORMAL);
         return 8;
     }
 
@@ -360,6 +439,6 @@ main(int argc, char **argv)
         }
     }
 
-    ufsd_shutdown(&ufsd, 1);      /* clean STOP: quiesce in-flight clients */
+    ufsd_shutdown(&ufsd, UFSD_SHUT_NORMAL);   /* clean STOP */
     return 0;
 }

--- a/src/ufsdclnp.c
+++ b/src/ufsdclnp.c
@@ -86,6 +86,13 @@ main(int argc, char **argv)
     ** pool blocks), then pools, then anchor itself.
     */
     if (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0) {
+        /* Diagnostic: report any clients that were still executing inside
+        ** UFSDSSIR when UFSD died.  These were orphaned -- their request
+        ** blocks are reclaimed with the pools below. */
+        if (anchor->inflight)
+            wtof("UFSD146W UFSDCLNP: %u client(s) were in flight",
+                 anchor->inflight);
+
         /* Free UFSDSSIR CSA load module */
         if (anchor->ssir_lpa) {
             freemain(anchor->ssir_lpa);


### PR DESCRIPTION
## Summary

Fixes the intermittent **S0C4 during `/P UFSD`** (#30). Revised after review:
the original fixed 6 s `STIMER WAIT` is **removed** — it narrowed the race
without closing it. Replaced with proper quiescing.

Three separate defects were fixed:

1. **Free-before-deregister + SSVT entry never nulled.** `ufsd_shutdown` freed
   UFSDSSIR *before* removing the registration, and `ufsd_ssct_free` never
   nulled the SSVT function pointer. Until that store, `iefssreq` kept routing
   new clients into an already-freed module — including into the entry check,
   which is itself an instruction in that module. Now the SSVT entry is nulled
   **first** (as UFSDCLNP does) and the SSCT is deregistered **before** the
   module is unloaded.

2. **No in-flight tracking.** The router only checked `ANCHOR_ACTIVE` on entry
   and on WAIT timeout, never before its phase-2 CSA writes. Added
   `anchor->inflight` (CS-guarded `__uinc`/`__udec` in key-0 windows,
   incremented after `free_pop`, decremented on every router exit path).
   Shutdown clears `ANCHOR_ACTIVE`, then **drains** the counter to zero (via
   `ecb_timed_wait` — the router's own proven timed-wait primitive, not a
   hand-rolled STIMER) before releasing CSA. A drain timeout **retains** CSA
   instead of freeing it (`UFSD098W`); UFSDCLNP reclaims.

3. **Timeout branch trusted stale flags.** Freed SP=241 storage is reused, not
   zeroed, so a stale high bit could leave a client looping forever on an ECB
   nobody posts. The timeout branch now revalidates the anchor eye catcher
   first; `ufsd_anchor_free` (and UFSDCLNP) clear it before the FREEMAIN. When
   the eye catcher is gone the client bails **without** touching the dead
   counter.

Two shutdown modes: `UFSD_SHUT_NORMAL` (clean `/P` — null entry, clear flag,
drain, free) and `UFSD_SHUT_ABEND` (ESTAE — null entry, clear flag, **free
nothing** and percolate; UFSDCLNP recovers). `/C UFSD` → `/S UFSDCLNP` is now
documented as the *designed* recovery, not a workaround (closes TSK-71).

Builds clean under `cc370 -Wall -Werror` (all 3 modules).

## ✅ Verified on MVS — 2026-07-13

Target `mvsdev.lan` (MVS 3.8j / Hercules), build `e1231d1`, all 3 modules
promoted into the runtime `UFSD.LINKLIB` (PUB000). In-flight load driven by
concurrent `GET /zosmf/restfiles/fs/tmp/big.dat` (mvsMF → libufs → UFSD).

| # | Scenario | Result | Evidence |
|---|----------|--------|----------|
| 1 | idle `/P` | ✅ **PASS** | `UFSD096I CSA freed` + `UFSD099I` ~1 s, no S0C4 |
| 2 | `/P` during transfer | ✅ **PASS** | superblocks → **~2 s drain gap** → `UFSD096I`, no S0C4, **no premature `UFSD098W`**; in-flight downloads bail `rc=1`; no client-side S0C4 |
| 4 | UFSDCLNP idle | ✅ **PASS** | `UFSD142I subsystem UFSD not registered`, CC 0000 |
| 3 | `/C` during transfer + UFSDCLNP | ⚠️ **partial** — see below | UFSD side clean; **new pre-existing defect surfaced** |

**The `/P` fix (i.e. #30) is validated.** Scenario 2 confirms the drain does
what it should: in-flight clients detected, ~2 s wait, CSA freed cleanly, no
S0C4. The failure tell we watched for — an *immediate* `UFSD098W` on an active
stop — did **not** occur. (Note: the drain waits for clients to *notice and
bail*, `rc=1`; it is not graceful request completion. Expected, and crash-free.)

**Scenario 3 surfaced a separate, pre-existing defect → #39.** On `/C`, the
UFSD side is clean (`UFSD098E` → `UFSD099I`, `S222`, CSA retained, no UFSD-AS
S0C4) and UFSDCLNP reclaims correctly with an accurate `UFSD146W: 5 client(s)
were in flight`. **But** UFSDCLNP frees the router module while clients are
still parked in it, so those clients take a **contained** S0C4 (5×
`MVSMF99E Handler abend S0C4`, caught by mvsMF's per-request ESTAE — HTTPD
survived). `git diff main...HEAD -- src/ufsdclnp.c` (the real PR range — #38 is
`6c3d0f4` + `e1231d1`) shows this PR only *added the `UFSD146W` diagnostic* to
UFSDCLNP (7 lines); its free-path is unchanged — so this is **not a regression
from this PR**. If anything #38 *improves* the path: it rewrote the router
timeout branch (`src/ufsd#ssi.c`) to revalidate the eye catcher and bail
`RC_CORRUPT`, so a parked client can now exit cleanly *if the module is still
present when it wakes* — UFSDCLNP frees it too early and defeats that. Tracked
in **#39** (fix shape: UFSDCLNP should drain like `/P`; `recovery.md`'s "clean
`RC_CORRUPT` bail within ~5 s" claim for `/C` is wrong).

**Minor:** `UFSD097W` is emitted in code (`ufsd.c:189`) but was dropped from
SYSLOG under `S222` termination (together with the `UFSD131I` superblock WTOs —
only the first `UFSD098E` and last `UFSD099I` survived). WTO loss during abend
teardown, not a code defect.

## Notes

- **All three load modules must be rebuilt & deployed together** — the anchor
  layout changed (`inflight` appended at the end, so existing offsets are
  unchanged, but UFSDSSIR/UFSDCLNP still need the new build).
- **Deploy target vs runtime library:** on `mvsdev` the STCs STEPLIB from
  `UFSD.LINKLIB` (PUB000, dynamically APF-authorized), **not** the mbt default
  `IBMUSER.UFSD.V1R0M0D.LINKLIB` (WORK00). Promote with IEBCOPY into the
  existing dataset — a re-targeted `make deploy` would delete+recreate it on
  WORK00 and drop APF.
- **Message-ID overlaps** (followed the review's exact strings): `UFSD097E`
  now also means "cannot enter supervisor state" (already used for SSCT install
  in `ufsd#sct.c`); `UFSD098E`/`UFSD098W` coexist. Flag for a later cleanup if
  unwanted.
- **Not done (optional, out of listed files):** surfacing `inflight` in
  `/F UFSD,STATS` (`ufsd#cmd.c`). Easy follow-up.

Refs #30, TSK-71 · follow-up #39
