### PR TITLE
Drain in-flight SSI clients in UFSDCLNP before freeing CSA (#39)

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -61,17 +61,20 @@ If JES2 still refuses the proc name, wait for the old job to be purged (check `$
 
 ### UFSDCLNP Details
 
-UFSDCLNP is a standalone program that locates the UFSD anchor in CSA via the SSCT chain, then tears down all resources in reverse order:
+UFSDCLNP is a standalone program that locates the UFSD anchor in CSA via the SSCT chain, then tears down all resources:
 
-1. Clears the SSVT function pointer (prevents new SSI calls)
-2. Deregisters and frees the SSCT
-3. Unloads the SSI router module from CSA
-4. Frees all CSA pools (trace ring, buffer pool, request pool)
-5. Frees the anchor itself
+1. Nulls the SSVT function pointer (no new SSI dispatches) and clears `UFSD_ANCHOR_ACTIVE` (a client parked in the router bails on its next timeout)
+2. **Drains `anchor->inflight` to zero** — keeping the eye catcher and the router module present — so a parked client bails `RC_CORRUPT` and leaves the module *before* it is freed (best-effort, ~12 s ceiling; see below)
+3. Deregisters and frees the SSCT
+4. Unloads the SSI router module from CSA
+5. Frees all CSA pools (trace ring, buffer pool, request pool)
+6. Invalidates the eye catcher and frees the anchor
+
+The drain (step 2) mirrors the clean-`/P` path and closes the window where freeing the router module out from under a parked client would S0C4 that client's address space (issue #39). It is **best-effort**: a count still standing after the ceiling is almost certainly leaked — a client that faulted or whose address space was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD146W … assuming leaked, freeing`) and frees anyway. Stranding CSA is the one failure UFSDCLNP exists to prevent, and it has no fallback but an IPL.
 
 UFSDCLNP is safe to run when UFSD is not registered — it reports "nothing to do" and exits RC=0.
 
-**Important:** Do not run UFSDCLNP while UFSD is still active. It will free the CSA under the running server, causing S0C4 on the next request or at shutdown. A future version will add a liveness check before cleanup.
+**Important:** Do not run UFSDCLNP while UFSD is *healthy and active*. It clears `UFSD_ANCHOR_ACTIVE` and frees the CSA, which pulls the storage out from under the running STC — an S0C4 in UFSD itself. The drain protects in-flight *clients* during recovery; it does not detect a live server. UFSDCLNP is for the post-abend case where the STC is already gone.
 
 ### Installation
 
@@ -83,7 +86,9 @@ Copy the UFSDCLNP STC procedure from `samplib/ufsdclnp` to `SYS2.PROCLIB(UFSDCLN
 
 After `/C UFSD` or any abend, the ESTAE handler runs in `UFSD_SHUT_ABEND` mode: it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` (so `iefssreq` stops routing new clients into UFSDSSIR and any parked client bails on its next router timeout), then percolates. It **frees nothing** — under RTM a foreign PSW may still be executing inside the router module or touching the CSA pools, and freeing them then is the very S0C4 this behaviour prevents.
 
-So `/S UFSDCLNP` is the **designed** recovery step after `/C` or an abend, not a workaround. UFSDCLNP nulls the SSVT entry (idempotent), deregisters the SSCT, and frees the router module, pools, and anchor. Because `ufsd_anchor_free`/UFSDCLNP invalidate the anchor eye catcher before the FREEMAIN, a client still looping in the router revalidates it on its next timeout and bails with `RC_CORRUPT` — a stuck HTTPD/FTPD worker does not hang indefinitely (worst case one `UFSD_WAIT_INTERVAL`, ~5 s).
+So `/S UFSDCLNP` is the **designed** recovery step after `/C` or an abend, not a workaround. UFSDCLNP nulls the SSVT entry (idempotent), clears `UFSD_ANCHOR_ACTIVE`, then **drains `anchor->inflight` to zero before it frees anything** — keeping the eye catcher and the router module present throughout. A client still parked in the router revalidates the (still-valid) eye catcher on its next timeout, sees the cleared flag, and bails `RC_CORRUPT`, decrementing the counter as it leaves. Only once the count reaches zero does UFSDCLNP deregister the SSCT and free the router module, pools, and anchor (invalidating the eye catcher just before the anchor FREEMAIN). This closes the window — present before #39 — where freeing the router out from under a parked client faulted that client's address space (`S0C4`; contained by a client-side ESTAE such as HTTPD's, fatal to a bare libufs batch client).
+
+The drain is **best-effort**, ceiling ~12 s (two `UFSD_WAIT_INTERVAL`s, so a live parked client gets two wake-and-bail chances). A count still standing after that is almost certainly leaked — a client that faulted or was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD146W`) and frees anyway rather than strand the CSA. So a genuinely stuck worker does not hang the cleanup indefinitely; worst case UFSDCLNP waits ~12 s, then reclaims.
 
 A clean `/P UFSD` (or `/F UFSD,SHUTDOWN`) runs in `UFSD_SHUT_NORMAL` mode instead: it nulls the SSVT entry, clears `UFSD_ANCHOR_ACTIVE`, then **drains** `anchor->inflight` to zero and frees the CSA itself — no UFSDCLNP needed after a normal stop. If the drain does not reach zero within its ceiling (~10 s), UFSD issues `UFSD098W` and retains the CSA rather than freeing storage a client may still be executing; run `/S UFSDCLNP` in that case.
 
@@ -156,7 +161,7 @@ All UFSD messages follow the `UFSDnnnS` pattern, where `nnn` is the message numb
 | UFSD143I | I | SSI router module freed |
 | UFSD144I | I | CSA pools freed |
 | UFSD145I | I | Anchor freed |
-| UFSD146W | W | Clients were in flight when UFSD died (diagnostic) |
+| UFSD146W | W | Client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
 | UFSD149I | I | UFSDCLNP complete |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/src/ufsdclnp.c
+++ b/src/ufsdclnp.c
@@ -14,6 +14,18 @@
 **   /S UFSDCLNP       (30 seconds, replaces 15-minute IPL)
 **   /S UFSD
 **   /S HTTPD
+**
+** Quiescing (#39): UFSDCLNP mirrors the clean-/P path.  It nulls the
+** SSVT entry and clears UFSD_ANCHOR_ACTIVE, then DRAINS anchor->inflight
+** to zero -- keeping the eye catcher and the router module present -- so
+** a client still parked in UFSDSSIR bails RC_CORRUPT on its next timeout
+** and leaves the module before we free it.  Freeing the router out from
+** under a parked client is an S0C4 in that client's address space (see
+** issue #39); the drain closes that window.  It is best-effort: a count
+** still standing after the ceiling is almost certainly leaked (a client
+** that faulted or whose AS was cancelled while in-flight never runs its
+** decrement), so we warn and free anyway -- UFSDCLNP has no fallback but
+** an IPL, and stranding CSA is exactly what it exists to prevent.
 */
 
 #include "ufsd.h"
@@ -23,6 +35,42 @@
 #include <clibssct.h>
 #include <clibssvt.h>
 
+/* Drain tuning -- see ufsd.c ufsd_drain().  The ceiling exceeds
+** 2 * UFSD_WAIT_INTERVAL (2 * 5.00 s) so a client genuinely parked in the
+** router gets two wake-and-bail chances before we conclude the count is
+** leaked and free anyway. */
+#define UFSDCLNP_DRAIN_POLL    10U   /* 0.10 s per poll                    */
+#define UFSDCLNP_DRAIN_MAX    120U   /* 120 * 0.10 s = 12.00 s ceiling     */
+#define UFSDCLNP_DRAIN_SETTLE  20U   /* 0.20 s after inflight reaches zero */
+
+/* Block for `hsec` hundredths on a private stack ECB nobody posts -- the
+** interval timer wakes us.  Same primitive as ufsd_pause() in the STC. */
+static void
+ufsdclnp_pause(unsigned hsec)
+{
+    ECB local = 0;
+    ecb_timed_wait(&local, hsec, 0);
+}
+
+/* Poll anchor->inflight to zero.  Returns 1 if it drained, 0 on ceiling.
+** Runs in problem state: inflight is in CSA without fetch-protection and
+** another address space decrements it (volatile: reload every poll). */
+static int
+ufsdclnp_drain(UFSD_ANCHOR *anchor)
+{
+    volatile unsigned *inflight = &anchor->inflight;
+    unsigned           n;
+
+    for (n = 0; n < UFSDCLNP_DRAIN_MAX; n++) {
+        if (*inflight == 0) {
+            ufsdclnp_pause(UFSDCLNP_DRAIN_SETTLE);
+            return (*inflight == 0);      /* re-check: catch a racing exit */
+        }
+        ufsdclnp_pause(UFSDCLNP_DRAIN_POLL);
+    }
+    return 0;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -30,6 +78,7 @@ main(int argc, char **argv)
     SSVT           *ssvt;
     UFSD_ANCHOR    *anchor;
     unsigned char   savekey;
+    int             anchor_ok;
     int             rc;
 
     (void)argc;
@@ -50,49 +99,56 @@ main(int argc, char **argv)
         return 0;
     }
 
-    /* --- Enter supervisor state key-0 for all CSA operations --- */
+    ssvt      = ssct->ssctssvt;
+    anchor    = (UFSD_ANCHOR *)ssct->ssctsuse;
+    anchor_ok = (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0);
+
+    /* --- Step 1: close the door and arm the parked-client bail ---
+    ** Null the SSVT entry so no NEW iefssreq call dispatches into UFSDSSIR,
+    ** and clear UFSD_ANCHOR_ACTIVE so a client already parked in the router
+    ** bails RC_CORRUPT on its next timeout.  Keep the eye catcher and the
+    ** router module present: the router decrements inflight ONLY on the
+    ** "eye still valid" bail path, so clearing the eye now would strand the
+    ** counter and defeat the drain in step 2. */
     if (__super(PSWKEY0, &savekey)) {
         wtof("UFSD143E UFSDCLNP: cannot enter supervisor state");
         return 8;
     }
-
-    /* --- Step 1: Null the SSVT function pointer immediately ---
-    ** This stops any new IEFSSREQ calls from dispatching to the
-    ** (now gone) UFSDSSIR module.  In-flight calls that already
-    ** entered the router will complete or abend on their own;
-    ** the important thing is no NEW calls can start.
-    */
-    ssvt = ssct->ssctssvt;
     if (ssvt) {
         ssvt_reset(ssvt, UFSD_SSVT_ROUTER);
         ssvt_funcmap(ssvt, 0, UFSD_SSOBFUNC);
         wtof("UFSD144I UFSDCLNP: SSVT function pointer cleared");
     }
+    if (anchor_ok)
+        anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
+    __prob(savekey, NULL);
 
-    /* --- Step 2: Grab anchor before unchaining SSCT --- */
-    anchor = (UFSD_ANCHOR *)ssct->ssctsuse;
+    /* --- Step 2: drain in-flight clients out of the router (problem
+    ** state) --- parked clients need up to one UFSD_WAIT_INTERVAL to notice
+    ** the cleared flag and bail, decrementing inflight on the way out.
+    ** Best-effort: a count still standing after the ceiling is treated as
+    ** leaked and freed anyway (see file header). */
+    if (anchor_ok && anchor->inflight) {
+        if (!ufsdclnp_drain(anchor))
+            wtof("UFSD146W UFSDCLNP: %u client(s) still in flight after "
+                 "drain -- assuming leaked, freeing", anchor->inflight);
+    }
 
-    /* --- Step 3: Unchain SSCT from JESCT and free SSCT+SSVT --- */
+    /* --- Step 3: tear down under key-0 -- deregister the SSCT (frees the
+    ** SSVT), unload the router module, release the pools, then the anchor.
+    ** Order matters: the module references the pool blocks, so it goes
+    ** first; the anchor goes last. */
+    if (__super(PSWKEY0, &savekey)) {
+        wtof("UFSD143E UFSDCLNP: cannot enter supervisor state");
+        return 8;
+    }
+
     ssct_remove(ssct);
     ssct_free(ssct);
     if (ssvt) ssvt_free(ssvt);
     wtof("UFSD145I UFSDCLNP: SSCT deregistered");
 
-    /* --- Step 4: Free CSA pools if anchor looks valid ---
-    ** We check the eye catcher to avoid freeing random storage
-    ** if ssctsuse was corrupt or zero.
-    **
-    ** Order matters: SSI router module first (it references the
-    ** pool blocks), then pools, then anchor itself.
-    */
-    if (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0) {
-        /* Diagnostic: report any clients that were still executing inside
-        ** UFSDSSIR when UFSD died.  These were orphaned -- their request
-        ** blocks are reclaimed with the pools below. */
-        if (anchor->inflight)
-            wtof("UFSD146W UFSDCLNP: %u client(s) were in flight",
-                 anchor->inflight);
-
+    if (anchor_ok) {
         /* Free UFSDSSIR CSA load module */
         if (anchor->ssir_lpa) {
             freemain(anchor->ssir_lpa);
@@ -122,7 +178,10 @@ main(int argc, char **argv)
 
         wtof("UFSD147I UFSDCLNP: CSA pools freed");
 
-        /* Free anchor itself (must be last) */
+        /* Invalidate the eye catcher BEFORE the FREEMAIN so a client still
+        ** in the drain settle window bails on eye-mismatch instead of
+        ** trusting a live-looking anchor.  Anchor goes last. */
+        memset(anchor->eye, 0, sizeof(anchor->eye));
         freemain(anchor);
         wtof("UFSD148I UFSDCLNP: anchor freed");
     } else if (anchor) {


### PR DESCRIPTION
## Summary

Fixes #39: on the `/C` (or abend) recovery path, `UFSDCLNP` freed the router
module and CSA **immediately**, even with clients still parked in the router's
`ecb_timed_wait`. When those clients woke they returned into freed/reused CSA →
`S0C4` in their address space (contained by a client-side ESTAE such as HTTPD's,
fatal to a bare libufs batch client). MVS verification of #38 caught this (5×
`MVSMF99E Handler abend S0C4` on a `/C`-during-transfer); it is pre-existing —
#38 only added the `UFSD146W` diagnostic that made it visible.

## Change

`UFSDCLNP` now mirrors the clean-`/P` quiesce:

1. Null the SSVT entry **and clear `UFSD_ANCHOR_ACTIVE`** (parked clients bail on
   their next timeout) — keeping the **eye catcher and router module present**.
   Clearing the eye here would send clients down the `!eye_ok` bail path, which
   deliberately skips the `inflight` decrement — stranding the counter and
   defeating the drain. So the eye is cleared only at the very end.
2. **Drain `anchor->inflight` to zero** in problem state (poll via
   `ecb_timed_wait`), so parked clients bail `RC_CORRUPT` and leave the module
   before it is freed.
3. Only then deregister the SSCT and free module → pools → anchor (eye
   invalidated just before the anchor FREEMAIN).

**Best-effort** (per maintainer decision): the drain ceiling is ~12 s (2×
`UFSD_WAIT_INTERVAL`, giving a live parked client two wake-and-bail chances). A
count still standing after that is almost certainly leaked — a client that
faulted or whose AS was cancelled while in-flight never runs its decrement — so
UFSDCLNP warns (`UFSD146W … assuming leaked, freeing`) and frees anyway.
Stranding CSA is the one failure UFSDCLNP exists to prevent, and it has no
fallback but an IPL.

`docs/recovery.md` corrected: it previously claimed the `/C` path already gave a
clean `RC_CORRUPT` bail "within ~5 s".

Only `src/ufsdclnp.c` and `docs/recovery.md` change; the anchor layout is
**unchanged**, so only the UFSDCLNP load module needs redeploying (UFSD/UFSDSSIR
from #38 stay compatible). Builds clean under `cc370 -Wall -Werror` (all 3).

## ✅ Verified on MVS — 2026-07-14

Target `mvsdev.lan`; the updated UFSDCLNP promoted into `UFSD.LINKLIB` (PUB000).
Re-ran the exact #38 scenario-3 setup that produced **5× client `S0C4`** — now
clean. `/C UFSD` during an active transfer, then **prompt** `/S UFSDCLNP`:

```
03:11:56  C UFSD → UFSD098E → UFSD099I → S222
03:11:57  UFSD140I UFSDCLNP starting
03:11:57  UFSD144I SSVT function pointer cleared
              ⟵ ~5 s drain gap (one UFSD_WAIT_INTERVAL) ⟶
03:12:02  UFSD145I SSCT deregistered
03:12:02  UFSD146I SSI router module freed
03:12:02  UFSD147I / UFSD148I / UFSD149I     (clean free, complete)   CC 0000
```

- The **~5 s gap between `UFSD144I` and `UFSD145I` is the drain**: a client was
  in-flight (`inflight > 0`, else the gap is the ~0.2 s settle), UFSDCLNP kept
  the router module present, the parked client bailed `RC_CORRUPT` on its ~5 s
  timeout (`inflight → 0`), and only **then** did UFSDCLNP free.
- **No `UFSD146W`** → the drain reached zero cleanly (no leak, so no forced free).
- **No `MVSMF99E … S0C4`** → **no client S0C4**, versus 5× on the identical
  setup under #38. The window is closed.
- `/S UFSD` restarts clean afterward.

Refs #39
