### PR TITLE
docs: pre-release accuracy pass across docs/

### DIFF
--- a/docs/concept.md
+++ b/docs/concept.md
@@ -12,7 +12,7 @@ Revision 8 — Reflects completed Phase 4a (AP-4a)
 |---|------|--------|
 | 1 | SSI timed WAIT | Unconditional WAIT replaced with `ecb_timed_wait` loop (5 s interval). Checks `UFSD_ANCHOR_ACTIVE` after each timeout; returns `UFSD_RC_CORRUPT` if server is dead. Prevents client hangs (AP-4a #2). |
 | 2 | Superblock writeback | `ufsd_ufs_term` and `ufsd_disk_umount` call `ufsd_sb_write` for each RW disk before closing. Persists free block/inode caches (AP-4a #3). |
-| 3 | Logging cleanup | All WTO messages follow `UFSDnnnS` pattern. `UFSD-DBG` messages removed. UFSDCLNP messages assigned 140-149 range. Message number conflicts resolved across modules (AP-4a #5). |
+| 3 | Logging cleanup | All WTO messages follow `UFSDnnnX` pattern (X = severity I/W/E). `UFSD-DBG` messages removed. UFSDCLNP messages assigned 140-149 range. Message number conflicts resolved across modules (AP-4a #5). |
 | 4 | Startup banner | `UFSD000I` before init, `UFSD001I` with version, disk count, CSA size, session/file slot summary (AP-4a #5). |
 | 5 | Session cleanup | `SESSIONS PRUNE` command walks ASVT, detects terminated ASIDs, releases orphaned sessions with FDs and GFT entries (AP-4a #6). |
 | 6 | Test consolidation | Removed `ufsdping` (superseded by `/F UFSD,STATS`) and `ufsdtst` (superseded by `LIBUFTST`). `LIBUFTST` retained as sole regression tool (AP-4a #7). |
@@ -72,10 +72,11 @@ UFSD solves this by running the filesystem as a Subsystem Started Task (STC) wit
 │  │  UFSD_ANCHOR                               │       │
 │  │  ├─ HEAD/TAIL (CS lock-free queue)         │       │
 │  │  ├─ server_ecb / server_ascb               │       │
-│  │  ├─ Request Pool (32 × ~296B, CS pop/push) │       │
+│  │  ├─ Request Pool (32 × ~304B, CS pop/push) │       │
 │  │  ├─ 4K Buffer Pool (16 × 4K, CS pop/push) │       │
 │  │  ├─ Trace Ring (256 × 16B)                │       │
-│  │  └─ POST bundling (stat_posts_saved)       │       │
+│  │  ├─ POST bundling (stat_posts_saved)       │       │
+│  │  └─ inflight (quiesce on shutdown)         │       │
 │  └────────────────────────────────────────────┘       │
 │                       │     │  ESTAE recovery          │
 │                       │     │  UFSDCLNP (emergency)    │
@@ -101,24 +102,30 @@ Runs in the **client address space**. Contains **zero business logic**.
 1. Extract R1=SSOB via inline asm
 2. Validate SSOB eye catcher
 3. CS-pop request block from CSA free pool
-4. Copy parameters + ACEE userid/group into request
-5. FWRITE 4K: copy client buffer into CSA pool buffer
-6. CS lock-free enqueue (queue_append → returns was_empty)
-7. Conditional `__xmpost` (only if queue was previously empty)
-8. Switch to problem state, WAIT on stack ECB (key-8)
+4. `__uinc(anchor->inflight)` — mark this client in-flight (shutdown drains
+   this counter to zero before freeing the router module + pools)
+5. Copy parameters + ACEE userid/group into request
+6. FWRITE 4K: copy client buffer into CSA pool buffer
+7. CS lock-free enqueue (queue_append → returns was_empty)
+8. Conditional `__xmpost` (only if queue was previously empty)
+9. Switch to problem state, timed WAIT on stack ECB (key-8); on each timeout
+   revalidate the anchor eye catcher + `UFSD_ANCHOR_ACTIVE`, and bail
+   `UFSD_RC_CORRUPT` (giving back the in-flight count) if the server is gone
 
 **Phase 2 (result + cleanup):**
 1. Switch to supervisor state (key-0)
 2. FREAD 4K: copy CSA buffer to client destination, free buffer
 3. Copy result (rc, data) back to SSOB extension
 4. CS-push request block back to free pool
-5. Switch to problem state
+5. `__udec(anchor->inflight)` — decrement LAST, after every other CSA write,
+   so a shutdown drain observes this client gone only once it is done with CSA
+6. Switch to problem state
 
 ## 5. CSA Memory Model
 
 | Pool | Count | Unit Size | Total | Allocation |
 |------|-------|-----------|-------|------------|
-| Request | 32 | ~296B | ~9K | CS lock-free stack |
+| Request | 32 | ~304B | ~9K | CS lock-free stack |
 | Buffer | 16 | 4K | 64K | CS lock-free stack |
 | Trace | 256 | 16B | 4K | Ring buffer |
 | Anchor | 1 | ~512B | ~1K | Fixed |
@@ -185,40 +192,42 @@ are opened dynamically via SVC 99 (DYNALLOC) based on the Parmlib config.
 ```
 /* SYS1.PARMLIB(UFSDPRM0) */
 
-/* Root filesystem — auto-created by UFSD if missing */
-ROOT     DSN(SYS1.UFSD.ROOT) SIZE(1M) BLKSIZE(4096)
+/* Root filesystem — the dataset must already exist (see docs/disk-setup.md) */
+ROOT     DSN(UFSD.ROOT)
 
-/* Web server content (shipped with HTTPD, read-only) */
-MOUNT    DSN(HTTPD.WEBROOT)         PATH(/www)          MODE(RO)
+/* Read-only web content */
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 
-/* Custom sites (read-write, owner-restricted) */
-MOUNT    DSN(IBMUSER.SITE.SHOP)     PATH(/sites/shop)   MODE(RW) OWNER(IBMUSER)
+/* User home directories, writable only by their owner */
+MOUNT    DSN(IBMUSER.UFSHOME)    PATH(/u/ibmuser)    MODE(RW) OWNER(IBMUSER)
+MOUNT    DSN(MVSCE01.UFSHOME)    PATH(/u/mvsce01)    MODE(RW) OWNER(MVSCE01)
+MOUNT    DSN(MVSCE02.UFSHOME)    PATH(/u/mvsce02)    MODE(RW) OWNER(MVSCE02)
 
-/* User home directories */
-MOUNT    DSN(IBMUSER.UFSHOME)       PATH(/u/IBMUSER)    MODE(RW) OWNER(IBMUSER)
-MOUNT    DSN(HERC02.UFSHOME)        PATH(/u/HERC02)     MODE(RW) OWNER(HERC02)
-
-/* Anonymous FTP area */
-MOUNT    DSN(FTP.PUBLIC)            PATH(/ftp/pub)       MODE(RW) OWNER(FTPANON)
+/* Shared scratch area, writable by any authenticated user */
+MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
 ```
 
 ### 8.2 Root Disk
 
-On first startup, if the ROOT dataset does not exist, UFSD allocates it
-(DYNALLOC), formats it (`ufsd_disk_format`), and creates `/etc/`. The root
-disk is always mounted read-only for all clients. It provides the top-level
-namespace (`/www`, `/u`, `/sites`, `/ftp` are mount points on the root disk).
+The ROOT dataset must already exist and be UFS-formatted before startup —
+create it with `ufsd-utils` (see `docs/disk-setup.md`). UFSD opens it via
+DYNALLOC and fails to start if it is missing; it does **not** allocate or format
+disks itself. The root disk is mounted read-write only briefly during startup so
+the configured mount points can be created as directories, then flipped to
+read-only for all clients. It provides the top-level namespace (`/wwwroot`,
+`/u`, `/tmp` are mount points on the root disk).
 
 ### 8.3 Mount Namespace
 
 Each BDAM dataset is mounted on a path in a unified directory tree:
 
 ```
-/                        SYS1.UFSD.ROOT        RO   (auto-created)
-/www                     HTTPD.WEBROOT          RO   (default website)
-/sites/shop              IBMUSER.SITE.SHOP      RW   OWNER(IBMUSER)
-/u/IBMUSER               IBMUSER.UFSHOME        RW   OWNER(IBMUSER)
-/ftp/pub                 FTP.PUBLIC             RW   OWNER(FTPANON)
+/                        UFSD.ROOT             RO   (root filesystem)
+/wwwroot                 HTTPD.WEBROOT         RO   (read-only web content)
+/u/ibmuser               IBMUSER.UFSHOME       RW   OWNER(IBMUSER)
+/u/mvsce01               MVSCE01.UFSHOME       RW   OWNER(MVSCE01)
+/u/mvsce02               MVSCE02.UFSHOME       RW   OWNER(MVSCE02)
+/tmp                     UFSD.SCRATCH          RW   (any authenticated user)
 ```
 
 Mount points must exist as directories on the parent filesystem before
@@ -254,7 +263,7 @@ int ufsd_check_write(UFSD_DISK *disk, UFSD_SESSION *sess);
 UFSD provides the namespace and access control. Application-level routing
 is the client's job:
 
-- **HTTPD:** Configures `DOCROOT=/www`, virtual hosts via `VHOST ... DOCROOT=/sites/xxx`,
+- **HTTPD:** Configures `DOCROOT=/wwwroot`, virtual hosts via `VHOST ... DOCROOT=/sites/xxx`,
   user directories via `USERDIR=/u/*/public_html`. Pure URL-to-path mapping.
 - **FTPD:** Sets CWD to user home `/u/USERNAME` on login. Anonymous users
   get CWD `/ftp/pub` with chroot (FTPD prevents `..` above chroot).
@@ -265,8 +274,8 @@ is the client's job:
 Mounts can be added at runtime without restart:
 
 ```
-/F UFSD,MOUNT DSN=HERC02.SITE.WIKI,PATH=/sites/wiki,MODE=RW,OWNER=HERC02
-/F UFSD,UNMOUNT PATH=/sites/wiki
+/F UFSD,MOUNT DSN=PROJECT.DATA,PATH=/proj,MODE=RW
+/F UFSD,UNMOUNT PATH=/proj
 ```
 
 Dynamic mounts are not persisted — they are lost on UFSD restart. To make
@@ -282,45 +291,93 @@ Via `/F UFSD,<command>` using CIB/QEDIT:
 | `/F UFSD,UNMOUNT PATH=y` | Unmount path |
 | `/F UFSD,STATS` | Statistics (requests, errors, posts_saved, free counts) |
 | `/F UFSD,SESSIONS` | List active sessions |
+| `/F UFSD,SESSIONS PRUNE` | Release orphaned sessions (terminated ASIDs) |
 | `/F UFSD,TRACE ON\|OFF\|DUMP` | Control trace ring buffer |
 | `/F UFSD,REBUILD` | Force free block + inode cache rebuild |
+| `/F UFSD,HELP` | List available MODIFY commands |
 | `/F UFSD,SHUTDOWN` | Orderly shutdown |
 | `/P UFSD` | Standard MVS STOP |
 
+### 9.1 Shutdown and Quiesce (Issues #30/#39)
+
+All shutdown paths route through `ufsd_shutdown(ufsd, mode)`. The core hazard
+it addresses: an SSI client executes `ufsdssir` *in its own address space* out
+of the CSA-resident router module, so freeing that module or the CSA pools while
+a client is still inside them faults (S0C4) in the client — the exact abend this
+mechanism prevents.
+
+**Modes:**
+
+| Mode | Trigger | Action |
+|------|---------|--------|
+| `UFSD_SHUT_NORMAL` | Clean `/P`, `SHUTDOWN`, or startup failure | Null SSVT entry, clear `ANCHOR_ACTIVE`, **drain** in-flight clients, then free the CSA. |
+| `UFSD_SHUT_ABEND` | ESTAE recovery | Null SSVT entry + clear `ANCHOR_ACTIVE` only. No drain (STIMER under RTM is unsafe) and no CSA free — UFSDCLNP reclaims on the next start. |
+
+**In-flight counter (`anchor->inflight`).** The router `__uinc`s it right after
+the free-pool pop (in the entry key-0 window) and `__udec`s it on every exit
+path, always last — after all other CSA writes. A drain therefore observes a
+client gone only once it has finished touching CSA. `inflight` is appended at
+the end of `UFSD_ANCHOR` so the field offsets shared with UFSDSSIR/UFSDCLNP are
+unchanged, but all three load modules must still be rebuilt and deployed
+together.
+
+**Teardown order (identical in `ufsd_shutdown` NORMAL and in UFSDCLNP):**
+
+1. **Null the SSVT function entry** (`ssvt_reset` + `ssvt_funcmap`). Until this
+   store, `iefssreq` keeps dispatching new clients into UFSDSSIR — clearing
+   `ANCHOR_ACTIVE` alone does not stop that; only nulling the entry does. The
+   anchor eye catcher and router module are left present so parked clients can
+   still bail cleanly.
+2. **Clear `UFSD_ANCHOR_ACTIVE`.** A client parked in the 5 s timed WAIT bails
+   `UFSD_RC_CORRUPT` on its next timeout, decrementing `inflight` on the way out.
+3. **Drain** (`ufsd_drain`): poll `inflight` to zero — `UFSD_DRAIN_POLL`
+   (0.10 s per poll), `UFSD_DRAIN_MAX` (10.00 s ceiling), `UFSD_DRAIN_SETTLE`
+   (0.20 s re-check after it first reads zero, to catch a racing entry/exit). In
+   the STC a drain timeout means **retain CSA** (warn, free nothing). UFSDCLNP
+   runs the same drain with a 12.00 s ceiling but, as the last-resort recovery
+   tool, frees anyway after warning — it has no fallback but an IPL.
+4. **Free** in order: deregister the SSCT (which frees the SSVT), unload the
+   router module, then the session/global-file tables, the pools, and finally
+   the anchor (eye catcher cleared before the FREEMAIN).
+
+Quiescing is driven by the actual `inflight` count rather than a fixed sleep, so
+a clean `/P` with no clients in flight completes in a fraction of a second.
+
 ## 10. Client Library (libufs)
 
-`client/libufs.c` — ~30 functions providing POSIX-like API over UFSD IPC:
+`client/libufs.c` — ~36 functions providing POSIX-like API over UFSD IPC:
 
-- **Session:** `ufs_init`, `ufs_term`
-- **File I/O:** `ufs_fopen`, `ufs_fclose`, `ufs_fread`, `ufs_fwrite`, `ufs_fgetc`, `ufs_fputc`, `ufs_fputs`, `ufs_fgets`
-- **Directory:** `ufs_mkdir`, `ufs_rmdir`, `ufs_chdir`, `ufs_remove`, `ufs_getcwd`, `ufs_opendir`, `ufs_readdir`, `ufs_closedir`
-- **Optimizations:** 252-byte read-ahead buffer, 4K write-behind buffer, 4K CSA buffer pool path for large reads/writes
+- **Session:** `ufs_sys_new`, `ufs_sys_term`, `ufs_signon`, `ufs_signoff`, `ufs_setuser`
+- **File I/O:** `ufs_fopen`, `ufs_fclose`, `ufs_fread`, `ufs_fwrite`, `ufs_fgetc`, `ufs_fputc`, `ufs_fputs`, `ufs_fgets`, `ufs_fseek`, `ufs_feof`, `ufs_ferror`
+- **Directory:** `ufs_mkdir`, `ufs_rmdir`, `ufs_chgdir`, `ufs_remove`, `ufs_get_cwd`, `ufs_diropen`, `ufs_dirread`, `ufs_dirclose`
+- **Optimizations:** 4K read-ahead + 4K write-behind buffers (~8K per file handle), 4K CSA buffer pool path for large reads/writes
 
 ## 11. Source Modules
 
 | Module | File | Lines | Description |
 |--------|------|-------|-------------|
-| UFSD | `src/ufsd.c` | 320 | STC main, main loop, ESTAE, shutdown |
-| UFSD#CMD | `src/ufsd#cmd.c` | 316 | MODIFY command parser |
-| UFSD#CSA | `src/ufsd#csa.c` | 220 | CSA allocation, request pool |
+| UFSD | `src/ufsd.c` | 444 | STC main, main loop, ESTAE, shutdown/quiesce |
+| UFSD#CMD | `src/ufsd#cmd.c` | 357 | MODIFY command parser |
+| UFSD#CFG | `src/ufsd#cfg.c` | 245 | PARMLIB (UFSDPRMx) configuration parser |
+| UFSD#CSA | `src/ufsd#csa.c` | 225 | CSA allocation, request pool |
 | UFSD#BUF | `src/ufsd#buf.c` | 78 | 4K buffer pool (CS lock-free) |
 | UFSD#SCT | `src/ufsd#sct.c` | 159 | SSCT/SSVT registration |
-| UFSD#SSI | `src/ufsd#ssi.c` | 367 | SSI thin router |
-| UFSD#QUE | `src/ufsd#que.c` | 262 | Lock-free queue, dispatch routing |
-| UFSD#SES | `src/ufsd#ses.c` | 315 | Session management |
-| UFSD#INI | `src/ufsd#ini.c` | 393 | Disk init (DYNALLOC, BDAM open, mount) |
-| UFSD#BLK | `src/ufsd#blk.c` | 59 | BDAM block read/write |
-| UFSD#SBL | `src/ufsd#sbl.c` | 464 | Superblock, alloc, chain/inode/bitmap refill |
+| UFSD#SSI | `src/ufsd#ssi.c` | 436 | SSI thin router |
+| UFSD#QUE | `src/ufsd#que.c` | 274 | Lock-free queue, dispatch routing |
+| UFSD#SES | `src/ufsd#ses.c` | 434 | Session management |
+| UFSD#INI | `src/ufsd#ini.c` | 747 | Disk init (DYNALLOC, BDAM open, mount) |
+| UFSD#BLK | `src/ufsd#blk.c` | 80 | BDAM block read/write |
+| UFSD#SBL | `src/ufsd#sbl.c` | 486 | Superblock, alloc, chain/inode/bitmap refill |
 | UFSD#INO | `src/ufsd#ino.c` | 85 | Inode I/O |
 | UFSD#DIR | `src/ufsd#dir.c` | 326 | Directory lookup/add/remove |
-| UFSD#FIL | `src/ufsd#fil.c` | 1241 | File operation dispatch |
+| UFSD#FIL | `src/ufsd#fil.c` | 1464 | File operation dispatch |
 | UFSD#GFT | `src/ufsd#gft.c` | 119 | Global File Table |
 | UFSD#TRC | `src/ufsd#trc.c` | 109 | Trace ring buffer |
-| UFSDCLNP | `src/ufsdclnp.c` | 132 | Emergency cleanup (no-IPL recovery) |
-| LIBUFS | `client/libufs.c` | 864 | Client stub library |
-| **Total** | | **5829** | Server + client (excl. test programs) |
+| UFSDCLNP | `src/ufsdclnp.c` | 198 | Emergency cleanup + quiesce (no-IPL recovery) |
+| LIBUFS | `client/libufs.c` | 1010 | Client stub library |
+| **Total** | | **7276** | Server + client (excl. test programs) |
 
-Test programs: `client/ufsdping.c` (80), `client/ufsdtst.c` (330), `client/libufstst.c` (228).
+Test program: `client/libufstst.c` (345) — sole regression tool (`ufsdping` and `ufsdtst` removed, see AP-4a #7).
 
 ## 12. Known Limitations
 
@@ -340,7 +397,6 @@ Test programs: `client/ufsdping.c` (80), `client/ufsdtst.c` (330), `client/libuf
 | 5 | No RACF per-operation checking | Access control via mount-mode + owner check. Full RACHECK deferred. |
 | 6 | No NLST in FTPD | Not in reference implementation either. |
 | 7 | DIRREAD: direct blocks only | Directory with >1024 entries (4K blocks) would need indirect support. Unrealistic for MVS. |
-| 8 | No fseek | Sequential access only. Could be added to libufs if needed. |
 
 ## 13. Companion Projects
 
@@ -360,7 +416,7 @@ Test programs: `client/ufsdping.c` (80), `client/ufsdtst.c` (330), `client/libuf
 | **2a** | ✅ Done | Post-PoC Hardening | FWRITE 4K, timestamps, POST bundling, CS buf pool, write-behind, chain/inode refill, path validation, UFSDCLNP |
 | **3** | ✅ Done | Config + Mount Model | Parmlib, DYNALLOC, root-disk RO, mount traversal, check_write, ufs_setuser, SYNAD, superblock validation, S99 decode |
 | **4a** | ✅ Done | Beta Readiness | SSI timed WAIT, SB writeback, logging cleanup, session PRUNE, ufs_stat, RC fixes, ufsdrc.h, README |
-| **4b** | 🔲 Open | Beta Remaining | /F UFSD,CREATE, nested mount fix, ESTAE cleanup, UFSDCLNP separate proc |
+| **4b** | 🔲 Open | Beta Remaining | /F UFSD,CREATE, nested mount fix, UFSDCLNP separate proc (ESTAE cleanup done: structured `UFSD_SHUT_ABEND` quiesce + `inflight` drain, issues #30/#39) |
 | **5** | 🔲 Future | Multi-Worker | Pre-ATTACHed worker pool, inode/dir locking, SSI to LPA |
 | **6** | 🔲 Future | Extensions | VFS abstraction, double indirect, full RACF, pager/cache, ufsd-utils fsck |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ UFSD is configured through a Parmlib member, referenced by the `UFSDPRM` DD card
 /* Lines between slash-star are comments */
 
 ROOT     DSN(UFSD.ROOT)
-MOUNT    DSN(HTTPD.WEBROOT)      PATH(/www)          MODE(RW)
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 MOUNT    DSN(IBMUSER.UFSHOME)    PATH(/u/ibmuser)    MODE(RW) OWNER(IBMUSER)
 ```
 
@@ -57,7 +57,7 @@ UFSD enforces access control at three levels, applied in order:
 
 **Level 3 — RACF/RAKF per-file permissions.** Not implemented. There are no per-file or per-inode permission checks. The `mode` bits stored in inodes are informational only and not enforced by UFSD. Full RACF/RAKF integration with per-operation RACHECK is planned for a future release.
 
-The check is applied in `do_fopen` (write mode), `do_mkdir`, `do_rmdir`, `do_remove`, and `do_fwrite` — five call sites, one helper function:
+The check is applied in `do_fopen` (write mode), `do_mkdir`, `do_rmdir`, `do_remove`, and `do_fwrite` — six call sites (five functions; `do_fopen` calls the check twice), one helper function:
 
 ```c
 int ufsd_check_write(UFSD_DISK *disk, UFSD_SESSION *sess);
@@ -70,7 +70,7 @@ Each BDAM dataset is mounted on a path in a unified directory tree:
 
 ```
 /                        UFSD.ROOT              RO   (root filesystem)
-/www                     HTTPD.WEBROOT          RW   (web content)
+/wwwroot                 HTTPD.WEBROOT          RO   (web content)
 /u/ibmuser               IBMUSER.UFSHOME        RW   OWNER(IBMUSER)
 /u/mvsce01               MVSCE01.UFSHOME        RW   OWNER(MVSCE01)
 /tmp                     UFSD.SCRATCH           RW   (shared scratch)
@@ -90,7 +90,7 @@ ROOT     DSN(UFSD.ROOT)
 
 ```
 ROOT     DSN(UFSD.ROOT)
-MOUNT    DSN(HTTPD.WEBROOT)      PATH(/www)          MODE(RW)
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
 ```
 
@@ -98,7 +98,7 @@ MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
 
 ```
 ROOT     DSN(UFSD.ROOT)
-MOUNT    DSN(HTTPD.WEBROOT)      PATH(/www)          MODE(RW)
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 MOUNT    DSN(IBMUSER.UFSHOME)    PATH(/u/ibmuser)    MODE(RW) OWNER(IBMUSER)
 MOUNT    DSN(MVSCE01.UFSHOME)    PATH(/u/mvsce01)    MODE(RW) OWNER(MVSCE01)
 MOUNT    DSN(MVSCE02.UFSHOME)    PATH(/u/mvsce02)    MODE(RW) OWNER(MVSCE02)
@@ -147,15 +147,17 @@ Dynamic mounts are not persisted — they are lost on UFSD restart. To make them
 | `SESSIONS PRUNE` | Release sessions for terminated address spaces (stale ASID detection via ASVT walk) |
 | `SHUTDOWN` | Orderly shutdown (same as `/P UFSD`) |
 
+A normal `SHUTDOWN` or `/P UFSD` frees CSA cleanly. After an abnormal (abend) shutdown, CSA may be retained — run `UFSDCLNP` before restarting. See `docs/recovery.md`.
+
 ### Examples
 
 ```
 F UFSD,STATS
 F UFSD,SESSIONS
-F UFSD,MOUNT DSN=HTTPD.WEBROOT,PATH=/www,MODE=RW
+F UFSD,MOUNT DSN=PROJECT.DATA,PATH=/proj,MODE=RW
 F UFSD,MOUNT DSN=IBMUSER.UFSHOME,PATH=/u/ibmuser,MODE=RW,OWNER=IBMUSER
 F UFSD,MOUNT LIST
-F UFSD,UNMOUNT PATH=/www
+F UFSD,UNMOUNT PATH=/proj
 F UFSD,TRACE ON
 F UFSD,TRACE DUMP
 F UFSD,REBUILD
@@ -171,8 +173,8 @@ The STC procedure is provided in `samplib/ufsd`. Copy it to `SYS2.PROCLIB(UFSD)`
 //            D='SYS2.PARMLIB'
 //UFSD     EXEC PGM=UFSD,REGION=4M,TIME=1440
 //STEPLIB  DD  DISP=SHR,DSN=UFSD.LINKLIB
+//UFSDPRM  DD  DISP=SHR,DSN=&D(&M),FREE=CLOSE
 //SYSUDUMP DD  SYSOUT=*
-//UFSDPRM  DD  DSN=&D(&M),DISP=SHR,FREE=CLOSE
 ```
 
 ### Symbolic Parameters

--- a/docs/cross-as-reference.md
+++ b/docs/cross-as-reference.md
@@ -20,10 +20,55 @@ reference for cross-AS mechanics on MVS 3.8j under Hercules.
 | Operation | Mechanism | State | Notes |
 |-----------|-----------|-------|-------|
 | ufsdssir wakes STC | `__xmpost(server_ascb, &server_ecb, 0)` | supervisor | before `__prob` |
-| ufsdssir WAITs for reply | `WAIT ECB=(&local_ecb)` | problem | key-8 local ECB |
+| ufsdssir WAITs for reply | `ecb_timed_wait(&local_ecb, …)` retry loop | problem | key-8 local ECB; liveness-checked (see below) |
 | STC wakes client | `__xmpost(client_ascb, client_ecb_ptr, 0)` | supervisor | inside key-0 window |
 | client_ecb location | local stack var in ufsdssir | key-8 | **NOT** in CSA |
 | server_ecb location | `anchor->server_ecb` in CSA | key-0 | STC WAITs in supervisor |
+
+---
+
+## Reply-Wait Liveness and In-Flight Drain (post-AP-1c)
+
+The plain blocking `WAIT` above was later replaced by a timed,
+liveness-checked wait so a client parked in `ufsdssir` cannot hang
+forever if the STC shuts down or abends while its request is
+outstanding. The cross-AS state/key rules are unchanged — only the WAIT
+mechanism evolved (`src/ufsd#ssi.c`).
+
+**Timed wait loop.** Instead of one blocking `WAIT`, the router loops on
+`ecb_timed_wait(ecbp, UFSD_WAIT_INTERVAL, UFSD_TIMEOUT_CODE)`, where
+`UFSD_WAIT_INTERVAL` = 500 hundredths (5 s) and `UFSD_TIMEOUT_CODE` =
+X'0FFFF' is a sentinel post code, chosen distinct from the STC's normal
+reply (post code 0). A normal reply
+(`(*ecbp & ECB_VALUE_MASK) != UFSD_TIMEOUT_CODE`) breaks the loop; a timer
+pop drives the liveness check. Still key-8 local ECB, still in problem
+state — only the SVC 1 `WAIT` became a timed `STIMER`+`WAIT`.
+
+**Liveness check on timeout.** The router revalidates the anchor eye
+catcher (`memcmp(anchor->eye, "UFSDANCR", 8)`) and re-tests
+`UFSD_ANCHOR_ACTIVE`. Freed CSA (SP=241) is reused, not zeroed, so the
+flag alone cannot be trusted after an emergency shutdown — a stale high
+bit would loop forever on an ECB nobody will post, so the eye catcher is
+revalidated first.
+- Eye valid **and** ACTIVE set: server alive, no reply yet — clear the
+  ECB and re-issue the timed wait.
+- Server gone or quiescing: return `UFSD_RC_CORRUPT`. If the eye catcher
+  is still valid (a clean shutdown retains the anchor), give the
+  in-flight count back first — open a dedicated key-0 window and
+  `__udec(&anchor->inflight)` — so the drain can complete. If the eye
+  catcher is gone (anchor already freed by the emergency path / UFSDCLNP),
+  the counter no longer exists: do NOT write to it.
+
+**In-flight drain protocol** (`anchor->inflight`, key-0 CSA). Every
+client executing inside `ufsdssir` is counted: `__uinc(&anchor->inflight)`
+right after `free_pop` (inside the entry key-0 window), and
+`__udec(&anchor->inflight)` on every exit path from the router. Shutdown
+(`ufsd_shutdown`) and the emergency cleanup task (UFSDCLNP) clear
+`UFSD_ANCHOR_ACTIVE`, then drain `inflight` to zero before freeing the
+SSI router module and the CSA pools. This quiesces in-flight clients so
+CSA is never freed out from under a request still copying its result. A
+drain that times out means "retain CSA" rather than risk freeing storage
+a client may still touch.
 
 ---
 
@@ -37,7 +82,7 @@ client's own ECB via inline `WAIT ECB=(%0)`.
 
 ## Abend 2: S0C4 / INTC=0x0010 — segment translation at ufsdssir entry
 
-**Root cause:** crent370's `iefssreq` passes R1 = SSOB address directly (MVS SSI
+**Root cause:** libc370's `iefssreq` passes R1 = SSOB address directly (MVS SSI
 convention). C calling convention expects R1 = pointer to parameter list.
 Declaring `ufsdssir(SSOB *ssob)` caused dereference of raw SSOB as C plist.
 
@@ -94,4 +139,4 @@ MVS routes system-internal SSI calls (job-step notifications) through ufsdssir
 which rejects them. After `/P UFSD` (deregisters SSCT), `S UFSD` works again.
 
 If UFSD abends without cleanup, SSCT remains registered until IPL. ESTAE exit
-is mandatory (see concept.md section 4.8).
+is mandatory (see concept.md, "SSI Router").

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,8 +7,8 @@ This document covers building UFSD from source, the server architecture, the com
 ### Prerequisites
 
 - Linux or macOS build host
-- `c2asm370` cross-compiler, GNU Make, Python 3.12+
-- MVS 3.8j system running the [mvsMF](https://github.com/mvslovers/mvsmf) REST API (port 1080 by default)
+- The `cc370` cross-toolchain (`cc370`, `as370`, `ld370`, `ar370`) on `PATH`, GNU Make, Python 3.12+
+- MVS 3.8j system running the [mvsMF](https://github.com/mvslovers/mvsmf) REST API (port 1080 by default) — only needed for `make deploy` and `make test-mvs`; the build itself runs entirely on the host
 - The `mbt` submodule is included in the repository
 
 ### Build Commands
@@ -33,13 +33,26 @@ MBT_MVS_DEPS_HLQ=IBMUSER.DEPS   # HLQ for dependency datasets
 Then build:
 
 ```sh
-make bootstrap    # fetch crent370 headers + NCALIB from GitHub
-make build        # cross-compile C → S/370 ASM, assemble on MVS
-make link         # linkedit load modules on MVS
-make package      # produce distribution archives
+make deps         # download + stage declared dependencies (none for ufsd today)
+make              # build the load modules on the host (default target)
+make lib          # build the libufs static archive (build/libufs.a)
+make package      # produce distribution archives in dist/
+make deploy       # XMIT + upload the load modules into the MVS LINKLIB
 ```
 
-The finished load modules land in `{HLQ}.UFSD.V1R0M0D.LOAD` on MVS. The build system uses `project.toml` for project metadata and dependency management. Dependencies (crent370) are resolved automatically by `mbt`.
+The entire build runs on the host with the `cc370` toolchain (`cc370` → `.o`,
+`as370`, `ld370`, `ar370`); MVS is touched only by `make deploy`. The load
+modules are written locally under `build/` (e.g. `build/UFSD.iebcopy`) and reach
+the MVS `LINKLIB` only after `make deploy`. The build is driven by `project.toml`
+(project metadata, modules, dependencies). `libc370` is the cc370 sysroot
+(`-lc`), not a declared dependency; `ufsd` itself currently declares no
+`[dependencies]`, so `make deps` is a no-op until one is added.
+
+Other targets: `make all` (modules + library), `make modules`, the test targets
+(`make test` / `test-host` / `test-mvs` / `check`, see [Testing](#testing)),
+`make doctor` (check the toolchain + MVS connectivity), `make compiledb` (write
+`compile_commands.json` for clangd), and `make clean` / `distclean`.
+`VERBOSE=1 make` echoes the full cc370/as370/ld370/ar370 commands.
 
 ### Project Structure
 
@@ -50,27 +63,59 @@ ufsd/
   client/            Client library and test programs
   samplib/           Sample JCL procedures and Parmlib member
   jcl/               Batch JCL
-  docs/              Documentation
-  doc/               Design documents (concept, disk spec)
-  project.toml       Build configuration and dependencies
+  docs/              Documentation and design docs (concept, disk spec)
+  mbt/               MVS Build Tools submodule (cc370 build system)
+  project.toml       Build configuration, modules, dependencies
+  Makefile           Two-line include of mbt/mk/mbt.mk
+  VERSION            Version string for release automation
+  mbt.lock           Resolved dependency pins (committed; empty when no deps)
 ```
 
 ### Installing libufs for Consumers
 
-Programs that call libufs need the header at compile time and the NCALIB member at link time.
+Programs that call libufs need the header at compile time and the `libufs.a`
+archive at link time. Both ship together in one release artifact.
 
-1. Download `ufsd-<version>-lib-headers.tar.gz` from the [Releases](https://github.com/mvslovers/ufsd/releases) page. Extract `libufs.h` and `ufsdrc.h` into your project's `include/`.
-
-2. Download `ufsd-<version>-lib-modules.tar.gz`, upload, and `RECEIVE` it to obtain the NCALIB dataset. Add it to your link JCL `SYSLIB` concatenation.
-
-With mbt, declare the dependency in your `project.toml`:
+The mbt v2 way — declare the dependency in your `project.toml`:
 
 ```toml
 [dependencies]
-"mvslovers/ufsd" = "=1.0.0-beta"
+"mvslovers/ufsd" = ">=1.0.0-dev"
 ```
 
-`make bootstrap` then fetches and installs everything automatically.
+`make deps` then resolves the range against the ufsd GitHub Releases, downloads
+`ufsd-<version>-lib.tar.gz`, and stages its `include/` + `lib/libufs.a` under
+`.mbt/deps/ufsd/`. The build wires these in automatically: `-I .mbt/deps/ufsd/include`
+on compile and `.mbt/deps/ufsd/lib/libufs.a` autocalled by `ld370` on link — no
+MVS-side link library or `SYSLIB` concatenation is involved. `make deps` also
+writes the resolved version + SHA256 to `mbt.lock` (commit it).
+
+To fetch the artifact by hand instead, download `ufsd-<version>-lib.tar.gz` from
+the [Releases](https://github.com/mvslovers/ufsd/releases) page and extract its
+`include/*.h` and `lib/libufs.a` into your project.
+
+## Testing
+
+Tests are declared as `[[test]]` blocks in `project.toml` (one translation unit
+with a `main()` each). UFSD ships one: `LIBUFTST` (`client/libufstst.c` +
+`client/libufs.c`), an integration test that exercises the libufs client API.
+
+Tests use `#include <mbtcheck.h>` and its `CHECK` / `CHECK_EQ` /
+`mbt_test_summary` macros — portable C, so the same source runs both natively on
+the host and on the MVS target. The only hard contract is the return code
+(`0` = all passed), which becomes the job-step condition code on MVS.
+
+```sh
+make test        # build the test load modules
+make test-host   # build + run the tests natively on the host — fast inner loop
+make test-mvs    # build + deploy the tests to a TESTLIB + run them on MVS
+make check       # run every available suite (host first, then MVS)
+```
+
+`make test-mvs` deploys to a separate `…TESTLIB` and prints a per-test pass/fail
+matrix. The production `LINKLIB` must already be deployed, since the MVS tests
+`LOAD` the server modules from it. Run only selected tests with
+`make test-mvs ARGS="--only LIBUFTST"`.
 
 ## Architecture
 
@@ -103,16 +148,16 @@ No Cross-Memory Services (PC/PT) are available on S/370. The IPC uses IEFSSREQ (
 
 | Module | File | Lines | Description |
 |--------|------|-------|-------------|
-| UFSD | `src/ufsd.c` | 335 | STC main, dispatch loop, ESTAE, shutdown |
+| UFSD | `src/ufsd.c` | 444 | STC main, dispatch loop, ESTAE, shutdown |
 | UFSD#CMD | `src/ufsd#cmd.c` | 357 | MODIFY command parser |
 | UFSD#CFG | `src/ufsd#cfg.c` | 245 | Parmlib parser |
-| UFSD#CSA | `src/ufsd#csa.c` | 220 | CSA allocation, request pool |
+| UFSD#CSA | `src/ufsd#csa.c` | 225 | CSA allocation, request pool |
 | UFSD#BUF | `src/ufsd#buf.c` | 78 | 4K buffer pool (CS lock-free) |
 | UFSD#SCT | `src/ufsd#sct.c` | 159 | SSCT/SSVT registration |
-| UFSD#SSI | `src/ufsd#ssi.c` | 392 | SSI thin router (runs in client AS) |
-| UFSD#QUE | `src/ufsd#que.c` | 273 | Lock-free queue, dispatch routing |
+| UFSD#SSI | `src/ufsd#ssi.c` | 436 | SSI thin router (runs in client AS) |
+| UFSD#QUE | `src/ufsd#que.c` | 274 | Lock-free queue, dispatch routing |
 | UFSD#SES | `src/ufsd#ses.c` | 434 | Session management |
-| UFSD#INI | `src/ufsd#ini.c` | 674 | Disk init (DYNALLOC, BDAM open, mount) |
+| UFSD#INI | `src/ufsd#ini.c` | 747 | Disk init (DYNALLOC, BDAM open, mount) |
 | UFSD#BLK | `src/ufsd#blk.c` | 80 | BDAM block read/write |
 | UFSD#SBL | `src/ufsd#sbl.c` | 486 | Superblock, alloc, chain/inode/bitmap refill |
 | UFSD#INO | `src/ufsd#ino.c` | 85 | Inode I/O |
@@ -120,10 +165,10 @@ No Cross-Memory Services (PC/PT) are available on S/370. The IPC uses IEFSSREQ (
 | UFSD#FIL | `src/ufsd#fil.c` | 1464 | File operation dispatch |
 | UFSD#GFT | `src/ufsd#gft.c` | 119 | Global File Table |
 | UFSD#TRC | `src/ufsd#trc.c` | 109 | Trace ring buffer |
-| UFSDCLNP | `src/ufsdclnp.c` | 132 | Emergency cleanup (no-IPL recovery) |
+| UFSDCLNP | `src/ufsdclnp.c` | 198 | Emergency cleanup (no-IPL recovery) |
 | LIBUFS | `client/libufs.c` | 1010 | Client stub library |
 | LIBUFTST | `client/libufstst.c` | 345 | Integration test client |
-| **Total** | | **~8200** | Server + client |
+| **Total** | | **~7600** | Server + client |
 
 ### On-Disk Format
 
@@ -131,7 +176,7 @@ The UFS370 on-disk format is documented in [docs/ufsdisk-spec.md](ufsdisk-spec.m
 
 ## libufs API Reference
 
-Include `libufs.h` and link against the `LIBUFS` NCALIB member.
+Include `libufs.h` and link against the `libufs.a` archive (staged by `make deps`, autocalled by `ld370`).
 
 ```c
 #include "libufs.h"
@@ -173,7 +218,7 @@ char     buf[256];
 UINT32   n;
 
 /* Open for writing */
-fp = ufs_fopen(ufs, "/www/hello.txt", "w");
+fp = ufs_fopen(ufs, "/u/ibmuser/hello.txt", "w");
 if (fp == NULL) {
     return 1;
 }
@@ -182,7 +227,7 @@ ufs_fputs("Hello, World!\n", fp);
 ufs_fclose(&fp);
 
 /* Open for reading */
-fp = ufs_fopen(ufs, "/www/hello.txt", "r");
+fp = ufs_fopen(ufs, "/u/ibmuser/hello.txt", "r");
 if (fp == NULL) {
     return 1;
 }
@@ -218,8 +263,8 @@ ufs_fclose(&fp);
 UFSDDESC *ddesc;
 UFSDLIST *entry;
 
-/* List all entries under /www matching "*.html" */
-ddesc = ufs_diropen(ufs, "/www", "*.html");
+/* List all entries under /u/ibmuser matching "*.html" */
+ddesc = ufs_diropen(ufs, "/u/ibmuser", "*.html");
 if (ddesc == NULL) {
     return 1;
 }
@@ -241,7 +286,7 @@ ufs_dirclose(&ddesc);
 Use `NULL` as the pattern to list all entries:
 
 ```c
-ddesc = ufs_diropen(ufs, "/www", NULL);
+ddesc = ufs_diropen(ufs, "/u/ibmuser", NULL);
 ```
 
 ### Directory and File Operations
@@ -261,7 +306,7 @@ ufs_remove(ufs, "/u/ibmuser/old.txt");
 
 /* Stat a file or directory (metadata without open) */
 UFSDLIST info;
-if (ufs_stat(ufs, "/www/index.html", &info) == 0) {
+if (ufs_stat(ufs, "/u/ibmuser/index.html", &info) == 0) {
     /* info.filesize, info.attr, info.owner, info.mtime, ... */
 }
 ```
@@ -334,8 +379,8 @@ ufs_clearerr(fp);
 ```c
 /*
  * Copy a local MVS dataset member into a UFSD filesystem.
- * Compile with: cc -I./include -o copy copy.c
- * Link against: LIBUFS NCALIB member
+ * Build via mbt v2: declare "mvslovers/ufsd" in project.toml, run
+ * `make deps`, then `make` -- ld370 autocalls libufs.a from .mbt/deps.
  */
 #include <stdio.h>
 #include <string.h>
@@ -362,7 +407,7 @@ int main(void)
         return 1;
     }
 
-    dst = ufs_fopen(ufs, "/www/upload.bin", "wb");
+    dst = ufs_fopen(ufs, "/u/ibmuser/upload.bin", "wb");
     if (dst == NULL) {
         fprintf(stderr, "ufs_fopen: failed\n");
         fclose(src);
@@ -399,7 +444,7 @@ libufs functions follow the standard IBM OS/VS C linkage convention:
 
 ```asm
 *----------------------------------------------------------------*
-* UFSDEMO -- read /www/index.html using libufs                   *
+* UFSDEMO -- read /u/ibmuser/index.html using libufs                   *
 *----------------------------------------------------------------*
 UFSDEMO  CSECT
 UFSDEMO  AMODE 24
@@ -430,7 +475,7 @@ UFSDEMO  RMODE 24
          LA    R2,OPENMODE
          ST    R2,P_MODE          plist slot: mode ptr value
          LA    R1,PL_FOPEN        R1 -> parameter list
-         L     R15,=V(UFS_FOPEN)
+         L     R15,=V(UFS#FOPN)
          BALR  R14,R15
          LTR   R15,R15            NULL = open failed
          BZ    ERROUT
@@ -447,7 +492,7 @@ UFSDEMO  RMODE 24
          L     R2,FILHDL
          ST    R2,P_FP            plist slot: UFSFILE* value
          LA    R1,PL_FREAD
-         L     R15,=V(UFS_FREAD)
+         L     R15,=V(UFS#FRD)
          BALR  R14,R15
          ST    R15,NREAD          bytes read returned in R15
 *
@@ -456,7 +501,7 @@ UFSDEMO  RMODE 24
          LA    R2,FILHDL          address of UFSFILE* variable
          ST    R2,P_FPP           plist slot: UFSFILE** value
          LA    R1,PL_FCLOSE
-         L     R15,=V(UFS_FCLOSE)
+         L     R15,=V(UFS#FCLS)
          BALR  R14,R15
 *
 *-- ufsfree(&ufshdl) ------------------------------------------*
@@ -506,7 +551,7 @@ PL_FFREE  DC   X'80',AL3(P_UFSPP) -> UFS**   [VL]
 UFSHDL   DS    A              UFS session handle
 FILHDL   DS    A              UFSFILE handle
 NREAD    DS    F              bytes read
-FILEPATH DC    C'/www/index.html',X'00'
+FILEPATH DC    C'/u/ibmuser/index.html',X'00'
 OPENMODE DC    C'r',X'00'
 READBUF  DS    CL256
 SAVEAREA DS    18F
@@ -514,6 +559,8 @@ SAVEAREA DS    18F
 ```
 
 ### Notes for Assembler Callers
+
+**External entry-point names use the 8-character MVS convention, not the C names.** `ufs_fopen` links as `UFS#FOPN`, `ufs_fread` as `UFS#FRD`, `ufs_fclose` as `UFS#FCLS`, and so on — consult the `asm("…")` labels in `libufs.h` for the exact entry name of each function. `ufsnew` and `ufsfree` keep their C names (`UFSNEW`, `UFSFREE`). The `#` is a valid national character in `as370` symbols.
 
 **`ufsnew` has no parameters.** Set R1 to zero or leave it undefined; the function does not dereference R1.
 

--- a/docs/disk-setup.md
+++ b/docs/disk-setup.md
@@ -48,10 +48,10 @@ Options:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--size` | — | Image size (e.g. `1M`, `500K`, `50M`) |
+| `--size` | `10M` | Image size (e.g. `1M`, `500K`, `50M`) |
 | `--blksize` | 4096 | Block size (512, 1024, 2048, 4096, 8192) |
 | `--inodes` | 10% | Percentage of blocks reserved for inodes |
-| `--owner` | `$USER` | Root directory owner (RACF userid) |
+| `--owner` | `$USER` → `HERC01` | Root directory owner (RACF userid); uppercased `$USER`, or `HERC01` if unset |
 | `--group` | `ADMIN` | Root directory group |
 
 ## Step 2: Populate Content
@@ -69,7 +69,15 @@ ufsd-utils cp -r ./wwwroot/ webroot.img:/
 ufsd-utils mkdir webroot.img:/css
 ```
 
-Files are automatically converted from ASCII to EBCDIC (IBM-1047). Binary files are copied as-is when using `--binary`.
+Text files are converted from ASCII to EBCDIC (IBM-1047), but the conversion is auto-detected from the file **extension** against a fixed allowlist (`.html`, `.htm`, `.txt`, `.css`, `.js`, `.xml`, `.json`, `.csv`, `.sh`, `.c`, `.h`, `.s`, `.md`, `.cfg`, `.conf`, `.toml`, `.yaml`, `.yml`, `.ini`, `.log`, `.jcl`, `.proc`). A file whose extension is **not** on the list (for example `.tmpl`, or a file with no extension) is copied as-is — still ASCII — and will be unreadable on MVS. Override the auto-detection explicitly:
+
+- `-t` forces text conversion (ASCII → EBCDIC), regardless of extension.
+- `-b` forces binary (copy the bytes verbatim, no conversion).
+
+```sh
+ufsd-utils cp -t config.tmpl webroot.img:/config.tmpl   # force ASCII -> EBCDIC
+ufsd-utils cp -b logo.png     webroot.img:/logo.png      # copy bytes verbatim
+```
 
 Verify the contents:
 
@@ -103,7 +111,7 @@ The upload command uses the zOSMF REST API. Authentication is configured via env
 
 ```sh
 export MVS_HOST=192.168.1.x
-export MVS_PORT=8080
+export MVS_PORT=1080
 export MVS_USER=IBMUSER
 export MVS_PASS=SYS1
 ```
@@ -121,13 +129,13 @@ ufsd-utils upload webroot.img --dsn HTTPD.WEBROOT --replace
 Add the dataset to your Parmlib member (`UFSDPRMx`):
 
 ```
-MOUNT    DSN(HTTPD.WEBROOT)      PATH(/www)          MODE(RW)
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 ```
 
 If UFSD is already running, mount dynamically without restart:
 
 ```
-/F UFSD,MOUNT DSN=HTTPD.WEBROOT,PATH=/www,MODE=RW
+/F UFSD,MOUNT DSN=HTTPD.WEBROOT,PATH=/wwwroot,MODE=RO
 ```
 
 ## MVS-Side Dataset Allocation
@@ -139,7 +147,7 @@ If you prefer to allocate the dataset manually on MVS (instead of using `ufsd-ut
 | DSORG | PS | Physical Sequential |
 | RECFM | U | Undefined record format |
 | BLKSIZE | 4096 | Must match the image's block size |
-| Space | Tracks or Cylinders | Calculated from image size |
+| Space | Blocks | Number of blocks in the image (matches the ISPF panel below) |
 
 **ISPF 3.2 panel values:**
 

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -15,11 +15,18 @@ Stop the daemon with `/P UFSD` or `/F UFSD,SHUTDOWN`. UFSD performs an orderly s
 Console output:
 
 ```
-UFSD090I UFSD shutting down
-UFSD091I Superblock written for DSN=IBMUSER.UFSHOME (/u/ibmuser)
-UFSD092I 3 filesystem(s) unmounted
+UFSD131I Superblock written for DSN=IBMUSER.UFSHOME
+UFSD131I Superblock written for DSN=UFSD.SCRATCH
+UFSD095I SSCT deregistered
+UFSD036I SSI router unloaded
+UFSD096I CSA freed
 UFSD099I UFSD shutdown complete
 ```
+
+(One `UFSD131I` per RW-mounted filesystem; RO mounts are not written back. If a
+client is still in flight when the stop is issued, a short drain delay precedes
+`UFSD095I`; if the drain does not reach zero within its ceiling the daemon
+issues `UFSD098W` and retains the CSA instead — run `/S UFSDCLNP` in that case.)
 
 ## Recovery after Abend
 
@@ -42,14 +49,18 @@ If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler runs in emergency
    Console output:
 
    ```
-   UFSDCLNP starting -- emergency UFSD cleanup
-   UFSDCLNP SSVT function pointer cleared
-   UFSDCLNP SSCT deregistered and freed
-   UFSDCLNP SSI router module freed
-   UFSDCLNP CSA pools freed (trace + buffers + requests)
-   UFSDCLNP anchor freed
-   UFSDCLNP complete -- UFSD can be restarted
+   UFSD140I UFSDCLNP starting
+   UFSD144I UFSDCLNP: SSVT function pointer cleared
+   UFSD145I UFSDCLNP: SSCT deregistered
+   UFSD146I UFSDCLNP: SSI router module freed
+   UFSD147I UFSDCLNP: CSA pools freed
+   UFSD148I UFSDCLNP: anchor freed
+   UFSD149I UFSDCLNP complete
    ```
+
+   (If clients were parked in the router when UFSD died, a short drain delay
+   precedes `UFSD145I` while they bail; a count still standing after the
+   ceiling yields `UFSD146W … assuming leaked, freeing` and cleanup proceeds.)
 
 2. Restart UFSD:
 
@@ -112,19 +123,32 @@ Concurrent writes to the same file from different sessions are not serialized. A
 
 ## WTO Message Reference
 
-All UFSD messages follow the `UFSDnnnS` pattern, where `nnn` is the message number and `S` is the severity (I=informational, W=warning, E=error).
+All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message number and `X` is the severity (I=informational, W=warning, E=error).
 
-### Startup and Shutdown (000–099)
+### Startup and Shutdown
 
 | Message | Severity | Description |
 |---------|----------|-------------|
-| UFSD000I | I | UFSD starting |
-| UFSD001I | I | Version banner with CSA summary |
+| UFSD000I | I | UFSD starting (version) |
+| UFSD001I | I | Ready — version + CSA/session/file summary |
+| UFSD030I | I | CSA anchor allocated |
+| UFSD031I–033I | I | Pool sizes (request pool / buffer pool / trace buffer) |
+| UFSD034I | I | SSCT registered |
+| UFSD035I | I | SSI router (UFSDSSIR) loaded into CSA |
+| UFSD045I | I | Session table allocated |
+| UFSD047I | I | Global file table allocated |
 | UFSD040I | I | Mount summary (n filesystems mounted) |
 | UFSD041I | I | Individual mount detail (path, DSN, mode, owner) |
-| UFSD090I | I | Shutdown initiated |
-| UFSD091I | I | Superblock written for disk |
-| UFSD092I | I | Filesystems unmounted |
+| UFSD060I | I | Mounted DSN on path |
+| UFSD090E | E | Cannot initialize console interface (startup fails) |
+| UFSD091E | E | APF setup failed — STEPLIB not APF-authorized (startup fails) |
+| UFSD092E | E | Cannot allocate CSA anchor (startup fails) |
+| UFSD130W | W | Superblock writeback failed for a disk at shutdown |
+| UFSD131I | I | Superblock written for DSN (one per RW filesystem) |
+| UFSD095I | I | SSCT deregistered |
+| UFSD036I | I | SSI router unloaded from CSA |
+| UFSD046I | I | Session table freed |
+| UFSD048I | I | Global file table freed |
 | UFSD096I | I | CSA freed |
 | UFSD097E | E | Cannot enter supervisor state at shutdown — CSA retained, run UFSDCLNP |
 | UFSD097W | W | Abend shutdown — CSA retained, run UFSDCLNP before restart |
@@ -156,12 +180,16 @@ All UFSD messages follow the `UFSDnnnS` pattern, where `nnn` is the message numb
 | Message | Severity | Description |
 |---------|----------|-------------|
 | UFSD140I | I | UFSDCLNP starting |
-| UFSD141I | I | SSVT function pointer cleared |
-| UFSD142I | I | SSCT deregistered and freed |
-| UFSD143I | I | SSI router module freed |
-| UFSD144I | I | CSA pools freed |
-| UFSD145I | I | Anchor freed |
+| UFSD141E | E | APF setup failed (STEPLIB not APF-authorized?) |
+| UFSD142I | I | Subsystem UFSD not registered — nothing to do (RC 0) |
+| UFSD143E | E | Cannot enter supervisor state |
+| UFSD144I | I | SSVT function pointer cleared |
+| UFSD145I | I | SSCT deregistered |
+| UFSD146I | I | SSI router module freed |
 | UFSD146W | W | Client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
+| UFSD147I | I | CSA pools freed |
+| UFSD148I | I | Anchor freed |
+| UFSD148W | W | Anchor eye-catcher mismatch — anchor not freed |
 | UFSD149I | I | UFSDCLNP complete |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/docs/ufsdisk-spec.md
+++ b/docs/ufsdisk-spec.md
@@ -175,6 +175,12 @@ The authoritative timestamps are in the boot extension (64-bit, ms).
 On version 0 disks, the superblock timestamps are 32-bit `time_t`
 (seconds since Unix epoch), which overflow after year 2106.
 
+**UFSD implementation note (`unused3`, offset 0x1FC):** Although the
+format defines this field as reserved/zero, UFSD reuses it at runtime as
+a free-block scan cursor. Because the superblock is written back as a
+whole 512-byte block, a **non-zero** value can reach disk. A host-side
+tool must not assume `unused3 == 0` and should ignore the field on read.
+
 ---
 
 ## 5. Inodes (Sectors 2 through datablock_start - 1)
@@ -244,9 +250,13 @@ sector = ilist_sector + (ino - 1) / inodes_per_block
 offset = ((ino - 1) % inodes_per_block) × 128
 ```
 
-Note: inode 0 occupies the first 128-byte slot in sector 2, but is
-never allocated. Inode 1 (BALBLK) occupies the second slot. Inode 2
-(root) is the third slot.
+Note: inode numbering is 1-based and there is **no physical slot for
+inode 0**. Under the `(ino - 1)` mapping above, inode 1 (BALBLK)
+occupies the first 128-byte slot in sector 2 (offset 0), inode 2 (root)
+occupies the second slot (sector 2, offset 128), and inode 3 the third
+slot (offset 256). The value 0 is never stored on disk — it is the
+"no inode" sentinel used in directory entries. (This is consistent with
+the formula above and with the reader algorithm in section 11.)
 
 ### 5.4 Mode Field (File Type + Permissions)
 
@@ -263,13 +273,20 @@ Bits     Mask     Value   Meaning
                   0x8000  Regular file
                   0xA000  Symbolic link (BSD extension)
                   0xC000  Socket (BSD extension)
-11..9    0x0E00           Owner permissions (rwx)
-8..6     0x01C0           Group permissions (rwx)
-5..3     0x0038           Other permissions (rwx)
-2..0     0x0007           (unused on UFS370)
+8..6     0x01C0           Owner permissions (rwx)
+5..3     0x0038           Group permissions (rwx)
+2..0     0x0007           Other permissions (rwx)
 ```
 
+Permission bits use the **standard Unix positions** (owner 8..6, group
+5..3, other 2..0), consistent with the `0x01ED` default value below.
+
 Default permission mask: `0755` (octal) = `0x01ED`.
+
+> **UFSD implementation note:** UFSD never interprets the rwx permission
+> bits — it only masks `mode & 0xF000` to obtain the file type. The
+> permission bits are stored (directories are created `0x41ED`, regular
+> files `0x81A4` = `0644`) but not enforced.
 
 ### 5.5 Block Address List (addr[0..18])
 
@@ -277,22 +294,32 @@ Default permission mask: `0755` (octal) = `0x01ED`.
 |-------|---------|
 | 0–15 | Direct block addresses (16 × blksize bytes) |
 | 16 | Single indirect block (points to block of UINT32 addresses) |
-| 17 | Double indirect block |
-| 18 | Triple indirect block |
+| 17 | Double indirect block (reserved; **not implemented in UFSD**) |
+| 18 | Triple indirect block (reserved; **not implemented in UFSD**) |
 
 **Maximum file sizes (4096-byte blocks):**
 
 | Addressing | Blocks | Max Size |
 |-----------|--------|----------|
 | Direct only (addr[0..15]) | 16 | 64 KB |
-| + Single indirect | 16 + 1024 | 4.06 MB |
-| + Double indirect | + 1,048,576 | 4.00 GB |
-| + Triple indirect | + 1,073,741,824 | 4.00 TB (theoretical) |
+| + Single indirect | 16 + 1024 | 4.06 MB — **UFSD effective maximum** |
+| + Double indirect | + 1,048,576 | 4.00 GB (format only; unimplemented in UFSD) |
+| + Triple indirect | + 1,073,741,824 | 4.00 TB theoretical (format only; unimplemented in UFSD) |
 
 An indirect block is a sector filled with UINT32 block addresses.
 Entries per indirect block: `blksize / sizeof(UINT32)` = `blksize / 4`.
 
 An address value of 0 means "not allocated" (sparse file / hole).
+
+> **UFSD implementation note:** UFSD reads and writes only direct
+> (addr[0..15]) and single-indirect (addr[16]) blocks. The addr[17] and
+> addr[18] slots are reserved by the format but never followed, so the
+> effective maximum file size under UFSD is **4.06 MB** (16 direct +
+> 1024 single-indirect blocks at 4 KB). A file written by another
+> format-compliant tool that uses double- or triple-indirect blocks is
+> **silently truncated on read** by UFSD: block resolution returns 0 for
+> any logical block beyond the single-indirect range, and the read stops
+> at that apparent hole.
 
 ---
 
@@ -376,6 +403,14 @@ Push the freed block number onto the superblock cache:
      sb.freeblock[0] = freed_block
 ```
 
+> **UFSD implementation note:** UFSD does **not** implement step 2. On
+> free-cache overflow (`nfreeblock == 51`) it simply drops the freed
+> block (leaked until the next remount or a REBUILD scan) instead of
+> spilling the cache into a chain block. UFSD therefore only *consumes*
+> V7 chain blocks — refilling the superblock cache when it empties (see
+> 7.3) — and never *produces* them. Chain blocks exist on disk only if
+> they were created at format time by `mkufs`.
+
 ---
 
 ## 8. Free Inode Management
@@ -389,31 +424,45 @@ entries to refill.
 
 ## 9. Multi-Disk and Mounting
 
+> **Scope:** This section describes *runtime* mount and configuration
+> behavior — **not** the on-disk format. The disk layout in sections 3–8
+> is independent of how a system discovers and mounts images. The
+> original ufs370 conventions are kept for reference; the current MVS
+> server (UFSD) uses a different scheme, documented alongside each.
+
 ### 9.1 DD Name Convention
 
-On MVS, disks are referenced by DD names: `UFSDISK0` through
-`UFSDISK9` (maximum 10 disks). `UFSDISK0` is always the root
-filesystem.
+**ufs370 (legacy):** disks were referenced by fixed DD names `UFSDISK0`
+through `UFSDISK9` (maximum 10 disks), with `UFSDISK0` as the root.
 
-### 9.2 fstab
+**UFSD (current):** UFSD supports up to **16** mounted filesystems
+(`UFSD_MAX_DISKS`). It does not use fixed `UFSDISK` DDs; instead it
+allocates each dataset dynamically via **DYNALLOC (SVC 99)**, generating
+sequential DD names of the form `UFDnnnnn` (`UFD00001`, `UFD00002`, …).
+The root filesystem is `disks[0]`, taken from the parmlib `ROOT`
+statement and mounted on `/`.
 
-The file `/etc/fstab` on the root disk controls additional mounts.
-Format (one entry per line):
+### 9.2 Configuration (parmlib, not fstab)
+
+**ufs370 (legacy):** additional mounts were listed in `/etc/fstab` on
+the root disk (one `ddname=NAME  path  type` entry per line).
+
+**UFSD (current):** UFSD does **not** read `/etc/fstab`. Mounts are
+configured in a PARMLIB member `SYS1.PARMLIB(UFSDPRMx)` (or `SYS2`, per
+the standard PARMLIB search order), read via `DD:UFSDPRM` at startup.
+The member uses keyword statements; comments are `/* … */` blocks:
 
 ```
-ddname=UFSDISK1  /disk1  ufs
-ddname=UFSDISK2  /data   ufs
+ROOT   DSN(UFSD.ROOT)       SIZE(1M)  BLKSIZE(4096)
+MOUNT  DSN(HTTPD.WEBROOT)   PATH(/wwwroot) MODE(RO)
+MOUNT  DSN(USER.HOME)       PATH(/u/USER)  MODE(RW) OWNER(USER)
 ```
 
-Or shorthand (DD name inferred from first field if <= 8 chars, no dots):
-```
-UFSDISK1  /disk1  ufs
-```
-
-Fields: `ddname=NAME` or `dsname=DS.NAME`, mount path, filesystem type.
-Lines starting with `#` are comments.
-
-The mount path directory must already exist on the root disk.
+A single `ROOT` statement declares the root dataset (mounted RW at `/`),
+and each `MOUNT` statement adds a filesystem (`DSN`, `PATH`, optional
+`MODE(RO|RW)` defaulting to `RO`, optional `OWNER`). The mount-point
+directory is created automatically on the appropriate parent filesystem
+if it does not already exist.
 
 ### 9.3 Host-Side Mounting
 
@@ -483,6 +532,9 @@ Starting from `datablock_start`, build the chain:
    - `ctime/mtime/atime = now` (time64 format)
    - `owner = "HERC01"` (or from RACF ACEE)
    - `group = "ADMIN"` (or from RACF ACEE)
+   - (UFSD note: directories that UFSD itself creates at runtime — e.g.
+     auto-created mount points via its internal `mkdir_p` — default to
+     `owner = "UFSD"`, `group = "SYS1"` rather than the `mkufs` values.)
 4. Write root data block:
    - Entry 0: `inode=2, name="."`
    - Entry 1: `inode=2, name=".."` (root parent is itself)

--- a/samplib/ufsdprm0
+++ b/samplib/ufsdprm0
@@ -1,7 +1,7 @@
 
 /* SYS2.PARMLIB(UFSDPRM0) */
 
-/* Root filesystem — auto-created if the dataset does not exist */
+/* Root filesystem — the dataset must already exist (see docs/disk-setup.md) */
 ROOT     DSN(UFSD.ROOT)
 
 /* Read-only web content */

--- a/src/ufsd#ini.c
+++ b/src/ufsd#ini.c
@@ -538,7 +538,7 @@ find_parent_disk(UFSD_STC *stc, const char *path)
 ** ufsd_ufs_init
 **
 ** AP-3a: Read parmlib configuration, mount root filesystem
-** (auto-create if missing), create mount-point directories,
+** (must already exist; not auto-created), create mount-point directories,
 ** then mount all configured filesystems.
 **
 ** Parmlib (DD:UFSDPRM) is required.  Returns 8 if missing.

--- a/src/ufsd#que.c
+++ b/src/ufsd#que.c
@@ -197,7 +197,8 @@ ufsd_dispatch(UFSD_ANCHOR *anchor, UFSREQ *req)
     /* --- Write result + post client ECB (key 0 for CSA write + __xmpost) ---
     ** __xmpost uses CVT0PT01 (POST branch entry), not SVC 2.
     ** It works for cross-AS POST and must be called from supervisor state.
-    ** req->client_ecb_ptr -> CSA ECB (key 0), accessible via CVT0PT01.
+    ** req->client_ecb_ptr -> the client's key-8 stack ECB (in the caller's
+    ** address space), posted cross-AS via CVT0PT01.
     ** req->client_ascb is the waiting task's ASCB (saved by ufsdssir).
     */
     if (!__super(PSWKEY0, &savekey)) {


### PR DESCRIPTION
## Summary

A pre-release accuracy pass over all seven `docs/` files, cross-checked against
the current source. Each document was independently reviewed against the code,
the fixes were applied, and a final independent verification pass confirmed the
result (no message ID, constant, function/asm name, mode mask, on-disk fact, or
build command in a changed hunk disagrees with the source).

## Per-document changes

- **development.md** — the largest gap. Rewrote the build/install/dependency
  sections for the **mbt v2 cc370 host build**: real `make` targets (dropped
  `bootstrap`/`build`/`link`), `c2asm370`→`cc370`, `crent370`→`libc370` (the
  cc370 sysroot `-lc`, not a declared dep), "whole build on the host; MVS only
  via `make deploy`", correct assembler entry names (`UFS#FOPN`/`UFS#FRD`/
  `UFS#FCLS`), correct release-artifact names, and a new **Testing** section
  (`[[test]]`/`LIBUFTST`, `test-host`/`test-mvs`, `mbtcheck.h`).
- **concept.md** — documented the **#30/#39 shutdown-quiesce** (`ufsd_shutdown`
  NORMAL/ABEND modes, `anchor->inflight` `__uinc`/`__udec` drain, teardown
  order, UFSDCLNP drain) in a new §9.1 and in the anchor diagram + router flow;
  removed the deleted test programs (`ufsdping`/`ufsdtst`); fixed client API
  names (`ufs_sys_new`/`ufs_signon`, `ufs_chgdir`, `ufs_diropen`…), the
  read/write buffer sizes, and the module table (added `ufsd#cfg.c`, refreshed
  counts); dropped the obsolete "no fseek" limitation.
- **ufsdisk-spec.md** — corrected the inode slot-numbering prose (`(ino-1)`;
  root = inode 2 at offset 128), the mode permission-bit masks
  (`0x01C0`/`0x0038`/`0x0007`), marked double/triple indirect
  reserved-but-unimplemented (**4.06 MB** effective max, silent truncation on
  read), noted the dealloc chain-spill is not implemented, and rewrote §9
  (multi-disk/mounting) to the current runtime (max 16 disks, `UFDnnnnn` via
  DYNALLOC, `SYS1.PARMLIB(UFSDPRMx)` — **not** `/etc/fstab`).
- **recovery.md** — replaced the shutdown and UFSDCLNP console examples and the
  two WTO tables with the message IDs the code **actually** emits
  (`UFSD131I`/`095I`/`036I`/`096I`… — the old `UFSD090I/091I/092I` never
  existed; the UFSDCLNP table was mis-numbered).
- **cross-as-reference.md** — added the current timed-wait / liveness /
  `inflight`-drain protocol (postdates the AP-1c note) and fixed a broken
  `concept.md §4.8` cross-reference.
- **configuration.md** / **disk-setup.md** — mount examples aligned to the
  shipped `samplib/ufsdprm0` (`HTTPD.WEBROOT /wwwroot RO`, `/u/…`, `/tmp`);
  ufsd-utils port corrected to **1080**; `cp` conversion description corrected
  (extension allowlist, `-t`/`-b` flags — `--binary` was not a real flag).

## Source/sample comment fixes (no behavior change)

- The root dataset is **not** auto-created — corrected the overclaiming comments
  in `samplib/ufsdprm0` and `src/ufsd#ini.c` (no `ufsd_disk_format` exists; the
  disk must be pre-allocated with `ufsd-utils`).
- `src/ufsd#que.c`: the client ECB is a **key-8 stack** ECB in the caller's
  address space, not a "CSA ECB (key 0)".

Docs only + comments; `make` still builds all three modules clean. No `mbt`
submodule change is included.
