### PR TITLE
Clean up WTO messages: unique IDs, upper-case text, inflight in STATS (#42)

### DIFF
--- a/docs/concept.md
+++ b/docs/concept.md
@@ -289,7 +289,7 @@ Via `/F UFSD,<command>` using CIB/QEDIT:
 |---------|-------------|
 | `/F UFSD,MOUNT DSN=x,PATH=y[,MODE=RO\|RW][,OWNER=z]` | Mount BDAM dataset on path |
 | `/F UFSD,UNMOUNT PATH=y` | Unmount path |
-| `/F UFSD,STATS` | Statistics (requests, errors, posts_saved, free counts) |
+| `/F UFSD,STATS` | Statistics (requests, errors, posts_saved, inflight, free counts) |
 | `/F UFSD,SESSIONS` | List active sessions |
 | `/F UFSD,SESSIONS PRUNE` | Release orphaned sessions (terminated ASIDs) |
 | `/F UFSD,TRACE ON\|OFF\|DUMP` | Control trace ring buffer |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ F UFSD,command
 
 | Command | Description |
 |---------|-------------|
-| `STATS` | Request counters, error count, POST bundles saved, free pool sizes, mounted filesystems with free block/inode counts |
+| `STATS` | Request counters, error count, POST bundles saved, in-flight client count, free pool sizes, mounted filesystems with free block/inode counts |
 | `SESSIONS` | List all active client sessions (userid, group, ASID, token, open FDs) |
 | `HELP` | Print a summary of available commands |
 

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -15,12 +15,12 @@ Stop the daemon with `/P UFSD` or `/F UFSD,SHUTDOWN`. UFSD performs an orderly s
 Console output:
 
 ```
-UFSD131I Superblock written for DSN=IBMUSER.UFSHOME
-UFSD131I Superblock written for DSN=UFSD.SCRATCH
-UFSD095I SSCT deregistered
-UFSD036I SSI router unloaded
-UFSD096I CSA freed
-UFSD099I UFSD shutdown complete
+UFSD131I SUPERBLOCK WRITTEN FOR DSN=IBMUSER.UFSHOME
+UFSD131I SUPERBLOCK WRITTEN FOR DSN=UFSD.SCRATCH
+UFSD095I SSCT DEREGISTERED
+UFSD036I SSI ROUTER UNLOADED
+UFSD096I CSA FREED
+UFSD099I UFSD SHUTDOWN COMPLETE
 ```
 
 (One `UFSD131I` per RW-mounted filesystem; RO mounts are not written back. If a
@@ -49,18 +49,18 @@ If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler runs in emergency
    Console output:
 
    ```
-   UFSD140I UFSDCLNP starting
-   UFSD144I UFSDCLNP: SSVT function pointer cleared
-   UFSD145I UFSDCLNP: SSCT deregistered
-   UFSD146I UFSDCLNP: SSI router module freed
-   UFSD147I UFSDCLNP: CSA pools freed
-   UFSD148I UFSDCLNP: anchor freed
-   UFSD149I UFSDCLNP complete
+   UFSD140I UFSDCLNP STARTING
+   UFSD144I UFSDCLNP: SSVT FUNCTION POINTER CLEARED
+   UFSD145I UFSDCLNP: SSCT DEREGISTERED
+   UFSD146I UFSDCLNP: SSI ROUTER MODULE FREED
+   UFSD147I UFSDCLNP: CSA POOLS FREED
+   UFSD148I UFSDCLNP: ANCHOR FREED
+   UFSD149I UFSDCLNP COMPLETE
    ```
 
    (If clients were parked in the router when UFSD died, a short drain delay
    precedes `UFSD145I` while they bail; a count still standing after the
-   ceiling yields `UFSD146W … assuming leaked, freeing` and cleanup proceeds.)
+   ceiling yields `UFSD152W … ASSUMING LEAKED, FREEING` and cleanup proceeds.)
 
 2. Restart UFSD:
 
@@ -81,7 +81,7 @@ UFSDCLNP is a standalone program that locates the UFSD anchor in CSA via the SSC
 5. Frees all CSA pools (trace ring, buffer pool, request pool)
 6. Invalidates the eye catcher and frees the anchor
 
-The drain (step 2) mirrors the clean-`/P` path and closes the window where freeing the router module out from under a parked client would S0C4 that client's address space (issue #39). It is **best-effort**: a count still standing after the ceiling is almost certainly leaked — a client that faulted or whose address space was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD146W … assuming leaked, freeing`) and frees anyway. Stranding CSA is the one failure UFSDCLNP exists to prevent, and it has no fallback but an IPL.
+The drain (step 2) mirrors the clean-`/P` path and closes the window where freeing the router module out from under a parked client would S0C4 that client's address space (issue #39). It is **best-effort**: a count still standing after the ceiling is almost certainly leaked — a client that faulted or whose address space was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD152W … ASSUMING LEAKED, FREEING`) and frees anyway. Stranding CSA is the one failure UFSDCLNP exists to prevent, and it has no fallback but an IPL.
 
 UFSDCLNP is safe to run when UFSD is not registered — it reports "nothing to do" and exits RC=0.
 
@@ -99,7 +99,7 @@ After `/C UFSD` or any abend, the ESTAE handler runs in `UFSD_SHUT_ABEND` mode: 
 
 So `/S UFSDCLNP` is the **designed** recovery step after `/C` or an abend, not a workaround. UFSDCLNP nulls the SSVT entry (idempotent), clears `UFSD_ANCHOR_ACTIVE`, then **drains `anchor->inflight` to zero before it frees anything** — keeping the eye catcher and the router module present throughout. A client still parked in the router revalidates the (still-valid) eye catcher on its next timeout, sees the cleared flag, and bails `RC_CORRUPT`, decrementing the counter as it leaves. Only once the count reaches zero does UFSDCLNP deregister the SSCT and free the router module, pools, and anchor (invalidating the eye catcher just before the anchor FREEMAIN). This closes the window — present before #39 — where freeing the router out from under a parked client faulted that client's address space (`S0C4`; contained by a client-side ESTAE such as HTTPD's, fatal to a bare libufs batch client).
 
-The drain is **best-effort**, ceiling ~12 s (two `UFSD_WAIT_INTERVAL`s, so a live parked client gets two wake-and-bail chances). A count still standing after that is almost certainly leaked — a client that faulted or was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD146W`) and frees anyway rather than strand the CSA. So a genuinely stuck worker does not hang the cleanup indefinitely; worst case UFSDCLNP waits ~12 s, then reclaims.
+The drain is **best-effort**, ceiling ~12 s (two `UFSD_WAIT_INTERVAL`s, so a live parked client gets two wake-and-bail chances). A count still standing after that is almost certainly leaked — a client that faulted or was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD152W`) and frees anyway rather than strand the CSA. So a genuinely stuck worker does not hang the cleanup indefinitely; worst case UFSDCLNP waits ~12 s, then reclaims.
 
 A clean `/P UFSD` (or `/F UFSD,SHUTDOWN`) runs in `UFSD_SHUT_NORMAL` mode instead: it nulls the SSVT entry, clears `UFSD_ANCHOR_ACTIVE`, then **drains** `anchor->inflight` to zero and frees the CSA itself — no UFSDCLNP needed after a normal stop. If the drain does not reach zero within its ceiling (~10 s), UFSD issues `UFSD098W` and retains the CSA rather than freeing storage a client may still be executing; run `/S UFSDCLNP` in that case.
 
@@ -175,7 +175,7 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD110I | I | Sessions list (from /F UFSD,SESSIONS) |
 | UFSD111I | I | Session pruned (stale ASID) |
 
-### UFSDCLNP (140–149)
+### UFSDCLNP (140–149, 152–154)
 
 | Message | Severity | Description |
 |---------|----------|-------------|
@@ -186,10 +186,11 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD144I | I | SSVT function pointer cleared |
 | UFSD145I | I | SSCT deregistered |
 | UFSD146I | I | SSI router module freed |
-| UFSD146W | W | Client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
 | UFSD147I | I | CSA pools freed |
 | UFSD148I | I | Anchor freed |
-| UFSD148W | W | Anchor eye-catcher mismatch — anchor not freed |
 | UFSD149I | I | UFSDCLNP complete |
+| UFSD152W | W | Client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
+| UFSD153W | W | Anchor eye-catcher mismatch — anchor not freed |
+| UFSD154I | I | No anchor (ssctsuse=NULL) — nothing to free |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/src/ufsd#blk.c
+++ b/src/ufsd#blk.c
@@ -42,7 +42,7 @@ ufsd_blk_read(UFSD_DISK *disk, unsigned sector, void *buf)
     if (oscheck(&decb)) {
         if (!disk->io_error) {
             disk->io_error = 1;
-            wtof("UFSD063E I/O error on DSN=%s block=%u (read)",
+            wtof("UFSD063E I/O ERROR ON DSN=%s BLOCK=%u (READ)",
                  disk->dsn, sector);
         }
         return UFSD_RC_IO;
@@ -71,7 +71,7 @@ ufsd_blk_write(UFSD_DISK *disk, unsigned sector, void *buf)
     if (oscheck(&decb)) {
         if (!disk->io_error) {
             disk->io_error = 1;
-            wtof("UFSD063E I/O error on DSN=%s block=%u (write)",
+            wtof("UFSD063E I/O ERROR ON DSN=%s BLOCK=%u (WRITE)",
                  disk->dsn, sector);
         }
         return UFSD_RC_IO;

--- a/src/ufsd#cfg.c
+++ b/src/ufsd#cfg.c
@@ -122,7 +122,7 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
 
     fp = fopen("DD:UFSDPRM", "r");
     if (!fp) {
-        wtof("UFSD100W Cannot open DD:UFSDPRM -- using defaults");
+        wtof("UFSD100W CANNOT OPEN DD:UFSDPRM -- USING DEFAULTS");
         return 8;
     }
 
@@ -168,8 +168,8 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
             UFSD_MOUNT_CFG *m;
 
             if (cfg->nmounts >= UFSD_CFG_MAX_MOUNTS) {
-                wtof("UFSD101W Parmlib: too many MOUNT statements "
-                     "(max %u)", (unsigned)UFSD_CFG_MAX_MOUNTS);
+                wtof("UFSD101W PARMLIB: TOO MANY MOUNT STATEMENTS "
+                     "(MAX %u)", (unsigned)UFSD_CFG_MAX_MOUNTS);
                 continue;
             }
 
@@ -178,13 +178,13 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
             m->mode = UFSD_MOUNT_RO;  /* default */
 
             if (!parse_param(p, "DSN", val, sizeof(val))) {
-                wtof("UFSD102W Parmlib: MOUNT missing DSN()");
+                wtof("UFSD102W PARMLIB: MOUNT MISSING DSN()");
                 continue;
             }
             strncpy(m->dsname, val, 44);
 
             if (!parse_param(p, "PATH", val, sizeof(val))) {
-                wtof("UFSD103W Parmlib: MOUNT missing PATH()");
+                wtof("UFSD103W PARMLIB: MOUNT MISSING PATH()");
                 continue;
             }
             strncpy(m->path, val, 127);
@@ -201,13 +201,13 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
             continue;
         }
 
-        wtof("UFSD104W Parmlib: unrecognized statement: %.40s", p);
+        wtof("UFSD104W PARMLIB: UNRECOGNIZED STATEMENT: %.40s", p);
     }
 
     fclose(fp);
 
     if (cfg->root_dsname[0] == '\0') {
-        wtof("UFSD105W Parmlib: ROOT statement missing");
+        wtof("UFSD105W PARMLIB: ROOT STATEMENT MISSING");
         return 8;
     }
 
@@ -226,19 +226,19 @@ ufsd_cfg_dump(const UFSD_CONFIG *cfg)
 
     if (!cfg) return;
 
-    wtof("UFSD110I Config: ROOT DSN=%s SIZE=%u BLKSIZE=%u",
+    wtof("UFSD110I CONFIG: ROOT DSN=%s SIZE=%u BLKSIZE=%u",
          cfg->root_dsname, cfg->root_size, cfg->root_blksize);
 
     for (i = 0; i < cfg->nmounts; i++) {
         const UFSD_MOUNT_CFG *m = &cfg->mounts[i];
 
         if (m->owner[0])
-            wtof("UFSD111I Config: MOUNT DSN=%s PATH=%s %s OWNER=%s",
+            wtof("UFSD111I CONFIG: MOUNT DSN=%s PATH=%s %s OWNER=%s",
                  m->dsname, m->path,
                  m->mode == UFSD_MOUNT_RW ? "RW" : "RO",
                  m->owner);
         else
-            wtof("UFSD111I Config: MOUNT DSN=%s PATH=%s %s",
+            wtof("UFSD111I CONFIG: MOUNT DSN=%s PATH=%s %s",
                  m->dsname, m->path,
                  m->mode == UFSD_MOUNT_RW ? "RW" : "RO");
     }

--- a/src/ufsd#cmd.c
+++ b/src/ufsd#cmd.c
@@ -68,8 +68,8 @@ ufsd_process_cib(UFSD_STC *ufsd, CIB *cib)
         } else if (strcmp(buf, "REBUILD") == 0) {
             cmd_rebuild(ufsd);
         } else {
-            wtof("UFSD021E Unknown command: %s", buf);
-            wtof("UFSD020I Commands: STATS, SESSIONS, MOUNT, UNMOUNT, TRACE, REBUILD, HELP, SHUTDOWN");
+            wtof("UFSD021E UNKNOWN COMMAND: %s", buf);
+            wtof("UFSD020I COMMANDS: STATS, SESSIONS, MOUNT, UNMOUNT, TRACE, REBUILD, HELP, SHUTDOWN");
         }
         break;
 
@@ -105,6 +105,7 @@ cmd_stats(UFSD_STC *ufsd)
         wtof("UFSD014I REQUESTS SERVED: %u", anchor->stat_requests);
         wtof("UFSD015I ERRORS:          %u", anchor->stat_errors);
         wtof("UFSD017I POSTS SAVED:     %u", anchor->stat_posts_saved);
+        wtof("UFSD016I IN FLIGHT:       %u", anchor->inflight);
     }
 
     for (i = 0; i < ufsd->ndisks; i++) {
@@ -112,13 +113,13 @@ cmd_stats(UFSD_STC *ufsd)
         if (!d) continue;
         if (d->mount_mode == UFSD_MOUNT_RW && d->mount_owner[0])
             wtof("UFSD018I MOUNT %-12s DSN=%-20s RW(%.8s) "
-                 "freeblk=%u/%u freeinode=%u/%u",
+                 "FREEBLK=%u/%u FREEINODE=%u/%u",
                  d->mountpath, d->dsn, d->mount_owner,
                  d->sb.nfreeblock, d->sb.total_freeblock,
                  d->sb.nfreeinode, d->sb.total_freeinode);
         else
             wtof("UFSD018I MOUNT %-12s DSN=%-20s %-2s "
-                 "freeblk=%u/%u freeinode=%u/%u",
+                 "FREEBLK=%u/%u FREEINODE=%u/%u",
                  d->mountpath, d->dsn,
                  d->mount_mode == UFSD_MOUNT_RW ? "RW" : "RO",
                  d->sb.nfreeblock, d->sb.total_freeblock,
@@ -131,11 +132,11 @@ cmd_sessions(UFSD_STC *ufsd, const char *args)
 {
     if (args && strcmp(args, "PRUNE") == 0) {
         unsigned n = ufsd_sess_cleanup(ufsd->anchor);
-        wtof("UFSD053I SESSIONS PRUNE: %u stale session(s) released", n);
+        wtof("UFSD053I SESSIONS PRUNE: %u STALE SESSION(S) RELEASED", n);
         return;
     }
     if (args && *args) {
-        wtof("UFSD021E SESSIONS: syntax: SESSIONS  or  SESSIONS PRUNE");
+        wtof("UFSD021E SESSIONS: SYNTAX: SESSIONS  OR  SESSIONS PRUNE");
         return;
     }
     ufsd_sess_list(ufsd->anchor);
@@ -145,13 +146,13 @@ static void
 cmd_help(UFSD_STC *ufsd)
 {
     (void)ufsd;
-    wtof("UFSD020I Commands: STATS, SESSIONS, MOUNT, UNMOUNT, TRACE, REBUILD, HELP, SHUTDOWN");
+    wtof("UFSD020I COMMANDS: STATS, SESSIONS, MOUNT, UNMOUNT, TRACE, REBUILD, HELP, SHUTDOWN");
     wtof("UFSD020I   MOUNT DSN=dsn,PATH=/path[,MODE=RW][,OWNER=user]");
     wtof("UFSD020I   MOUNT LIST");
     wtof("UFSD020I   UNMOUNT PATH=/path");
     wtof("UFSD020I   TRACE ON|OFF|DUMP");
-    wtof("UFSD020I   SESSIONS PRUNE  -- release stale sessions (terminated ASIDs)");
-    wtof("UFSD020I   REBUILD  -- scan inodes, rebuild free block/inode cache");
+    wtof("UFSD020I   SESSIONS PRUNE  -- RELEASE STALE SESSIONS (TERMINATED ASIDS)");
+    wtof("UFSD020I   REBUILD  -- SCAN INODES, REBUILD FREE BLOCK/INODE CACHE");
 }
 
 static void
@@ -183,13 +184,13 @@ cmd_mount(UFSD_STC *ufsd, const char *args)
     unsigned    i;
 
     if (!args || !*args) {
-        wtof("UFSD021E MOUNT: syntax: MOUNT DSN=dsn,PATH=/path  or  MOUNT LIST");
+        wtof("UFSD021E MOUNT: SYNTAX: MOUNT DSN=dsn,PATH=/path  OR  MOUNT LIST");
         return;
     }
 
     /* MOUNT LIST -- show all mounted filesystems */
     if (strcmp(args, "LIST") == 0) {
-        wtof("UFSD068I %u filesystem(s) mounted:", ufsd->ndisks);
+        wtof("UFSD068I %u FILESYSTEM(S) MOUNTED:", ufsd->ndisks);
         for (i = 0; i < ufsd->ndisks; i++) {
             UFSD_DISK *d = ufsd->disks[i];
             if (!d) continue;
@@ -214,7 +215,7 @@ cmd_mount(UFSD_STC *ufsd, const char *args)
 
         /* Parse PATH= */
         p = strstr(args, "PATH=");
-        if (!p) { wtof("UFSD021E MOUNT: PATH= not found"); return; }
+        if (!p) { wtof("UFSD021E MOUNT: PATH= NOT FOUND"); return; }
         p += 5;
         pathlen = 0;
         while (*p && *p != ',' && pathlen < 127)
@@ -244,7 +245,7 @@ cmd_mount(UFSD_STC *ufsd, const char *args)
         return;
     }
 
-    wtof("UFSD021E MOUNT: DSN= not found");
+    wtof("UFSD021E MOUNT: DSN= NOT FOUND");
 }
 
 /* ============================================================
@@ -260,7 +261,7 @@ cmd_unmount(UFSD_STC *ufsd, const char *args)
     int         pathlen;
 
     if (!args || !*args) {
-        wtof("UFSD021E UNMOUNT: syntax: UNMOUNT PATH=/path");
+        wtof("UFSD021E UNMOUNT: SYNTAX: UNMOUNT PATH=/path");
         return;
     }
 
@@ -277,7 +278,7 @@ cmd_unmount(UFSD_STC *ufsd, const char *args)
     mountpath[pathlen] = '\0';
 
     if (pathlen == 0) {
-        wtof("UFSD021E UNMOUNT: PATH is empty");
+        wtof("UFSD021E UNMOUNT: PATH IS EMPTY");
         return;
     }
 
@@ -304,7 +305,7 @@ cmd_trace(UFSD_STC *ufsd, const char *args)
                 __prob(savekey, NULL);
             }
         }
-        wtof("UFSD083I Trace enabled");
+        wtof("UFSD083I TRACE ENABLED");
     } else if (strcmp(args, "OFF") == 0) {
         if (anchor) {
             if (!__super(PSWKEY0, &savekey)) {
@@ -312,11 +313,11 @@ cmd_trace(UFSD_STC *ufsd, const char *args)
                 __prob(savekey, NULL);
             }
         }
-        wtof("UFSD083I Trace disabled");
+        wtof("UFSD083I TRACE DISABLED");
     } else if (strcmp(args, "DUMP") == 0) {
         ufsd_trace_dump(anchor);
     } else {
-        wtof("UFSD021E TRACE: syntax: TRACE ON|OFF|DUMP");
+        wtof("UFSD021E TRACE: SYNTAX: TRACE ON|OFF|DUMP");
     }
 }
 
@@ -333,7 +334,7 @@ cmd_rebuild(UFSD_STC *ufsd)
     int      rc;
 
     if (ufsd->ndisks == 0) {
-        wtof("UFSD071W REBUILD: no disks mounted");
+        wtof("UFSD071W REBUILD: NO DISKS MOUNTED");
         return;
     }
 
@@ -341,16 +342,16 @@ cmd_rebuild(UFSD_STC *ufsd)
         UFSD_DISK *d = ufsd->disks[i];
         if (!d) continue;
         if (d->flags & UFSD_DISK_RDONLY) {
-            wtof("UFSD072I REBUILD: skipping %.8s (read-only)", d->ddname);
+            wtof("UFSD072I REBUILD: SKIPPING %.8s (READ-ONLY)", d->ddname);
             continue;
         }
-        wtof("UFSD073I REBUILD: scanning %.8s ...", d->ddname);
+        wtof("UFSD073I REBUILD: SCANNING %.8s ...", d->ddname);
         rc = ufsd_sb_rebuild_free(d);
         if (rc == UFSD_RC_OK)
-            wtof("UFSD074I REBUILD: %.8s done, freeblk=%u freeinode=%u",
+            wtof("UFSD074I REBUILD: %.8s DONE, FREEBLK=%u FREEINODE=%u",
                  d->ddname, d->sb.nfreeblock, d->sb.nfreeinode);
         else
-            wtof("UFSD075E REBUILD: %.8s failed RC=%d",
+            wtof("UFSD075E REBUILD: %.8s FAILED RC=%d",
                  d->ddname, rc);
     }
 }

--- a/src/ufsd#csa.c
+++ b/src/ufsd#csa.c
@@ -83,7 +83,7 @@ ufsd_csa_init(UFSD_ANCHOR *anchor)
     unsigned        i;
 
     if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD038E Cannot enter supervisor state for CSA init");
+        wtof("UFSD038E CANNOT ENTER SUPERVISOR STATE FOR CSA INIT");
         return -1;
     }
 
@@ -140,7 +140,7 @@ ufsd_csa_init(UFSD_ANCHOR *anchor)
 
 fail:
     __prob(savekey, NULL);
-    wtof("UFSD039E Cannot allocate CSA pools");
+    wtof("UFSD039E CANNOT ALLOCATE CSA POOLS");
     return -1;
 }
 

--- a/src/ufsd#gft.c
+++ b/src/ufsd#gft.c
@@ -35,13 +35,13 @@ ufsd_gft_init(UFSD_ANCHOR *anchor)
 
     gfiles = (UFSD_GFILE *)calloc(UFSD_MAX_GFILES, sizeof(UFSD_GFILE));
     if (!gfiles) {
-        wtof("UFSD047E Cannot allocate global file table");
+        wtof("UFSD047E CANNOT ALLOCATE GLOBAL FILE TABLE");
         return 8;
     }
 
     if (__super(PSWKEY0, &savekey)) {
         free(gfiles);
-        wtof("UFSD048E Cannot enter supervisor state for GFT init");
+        wtof("UFSD048E CANNOT ENTER SUPERVISOR STATE FOR GFT INIT");
         return 8;
     }
     anchor->gfiles     = gfiles;

--- a/src/ufsd#ini.c
+++ b/src/ufsd#ini.c
@@ -111,11 +111,11 @@ ufsd_dynalloc(const char *ddname, const char *dsname, unsigned mode)
     if (rc != 0) {
         msg = s99_errmsg((unsigned short)rb.error);
         if (msg)
-            wtof("UFSD120E DYNALLOC failed for DSN=%s "
+            wtof("UFSD120E DYNALLOC FAILED FOR DSN=%s "
                  "(S99ERR=%04X: %s)", dsname,
                  (unsigned)rb.error, msg);
         else
-            wtof("UFSD120E DYNALLOC failed for DSN=%s "
+            wtof("UFSD120E DYNALLOC FAILED FOR DSN=%s "
                  "(S99ERR=%04X)", dsname,
                  (unsigned)rb.error);
 
@@ -127,8 +127,8 @@ ufsd_dynalloc(const char *ddname, const char *dsname, unsigned mode)
     return 0;
 
 bad_setup:
-    wtof("UFSD120E DYNALLOC failed for DSN=%s "
-         "(text unit build error)", dsname);
+    wtof("UFSD120E DYNALLOC FAILED FOR DSN=%s "
+         "(TEXT UNIT BUILD ERROR)", dsname);
     if (txt) FreeTXT99Array(&txt);
     return 8;
 }
@@ -154,7 +154,7 @@ open_disk(const char *ddname)
 
     disk = (UFSD_DISK *)calloc(1, sizeof(UFSD_DISK));
     if (!disk) {
-        wtof("UFSD042E Cannot allocate disk handle for %s", ddname);
+        wtof("UFSD042E CANNOT ALLOCATE DISK HANDLE FOR %s", ddname);
         return NULL;
     }
 
@@ -165,7 +165,7 @@ open_disk(const char *ddname)
     /* Allocate BDAM DCB */
     dcb = osddcb(disk->ddname);
     if (!dcb) {
-        wtof("UFSD042E Cannot allocate DCB for %s", disk->ddname);
+        wtof("UFSD042E CANNOT ALLOCATE DCB FOR %s", disk->ddname);
         free(disk);
         return NULL;
     }
@@ -187,7 +187,7 @@ open_disk(const char *ddname)
 
     /* Open for BDAM UPDATE access (read + write) */
     if (osdopen(dcb, 0)) {
-        wtof("UFSD043E Cannot open %s", disk->ddname);
+        wtof("UFSD043E CANNOT OPEN %s", disk->ddname);
         free(dcb);
         free(disk);
         return NULL;
@@ -219,7 +219,7 @@ open_disk(const char *ddname)
         boot = (UFSBOOT_HDR *)buf;
         if (boot->type != (unsigned short)UFSD_DISK_TYPE_UFS ||
             (unsigned)(boot->type + boot->check) != 0xFFFFU) {
-            wtof("UFSD044E %s: not a valid UFS disk (type=%04X)",
+            wtof("UFSD044E %s: NOT A VALID UFS DISK (TYPE=%04X)",
                  disk->ddname, (unsigned)boot->type);
             free(buf);
             close_disk(disk);
@@ -415,11 +415,11 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
     if (!stc || !dsname || !mountpath) return 8;
 
     if (mountpath[0] != '/') {
-        wtof("UFSD065E MOUNT: path must be absolute");
+        wtof("UFSD065E MOUNT: PATH MUST BE ABSOLUTE");
         return 8;
     }
     if (stc->ndisks >= (unsigned)UFSD_MAX_DISKS) {
-        wtof("UFSD061E MOUNT: disk table full (%u slots)",
+        wtof("UFSD061E MOUNT: DISK TABLE FULL (%u SLOTS)",
              (unsigned)UFSD_MAX_DISKS);
         return 8;
     }
@@ -428,7 +428,7 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
     for (i = 0; i < stc->ndisks; i++) {
         if (stc->disks[i] &&
             strcmp(stc->disks[i]->mountpath, mountpath) == 0) {
-            wtof("UFSD067E MOUNT: %s already mounted", mountpath);
+            wtof("UFSD067E MOUNT: %s ALREADY MOUNTED", mountpath);
             return 8;
         }
     }
@@ -449,7 +449,7 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
 
     /* Read and validate superblock */
     if (ufsd_sb_read(disk) != UFSD_RC_OK) {
-        wtof("UFSD124E Superblock read/validation failed for DSN=%s",
+        wtof("UFSD124E SUPERBLOCK READ/VALIDATION FAILED FOR DSN=%s",
              disk->dsn);
         close_disk(disk);
         __dsfree(ddname);
@@ -476,12 +476,12 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
     stc->disks[stc->ndisks++] = disk;
 
     if (disk->mount_owner[0])
-        wtof("UFSD060I Mounted %s on %s (%s, OWNER=%s)",
+        wtof("UFSD060I MOUNTED %s ON %s (%s, OWNER=%s)",
              disk->dsn, disk->mountpath,
              mode == UFSD_MOUNT_RW ? "RW" : "RO",
              disk->mount_owner);
     else
-        wtof("UFSD060I Mounted %s on %s (%s)",
+        wtof("UFSD060I MOUNTED %s ON %s (%s)",
              disk->dsn, disk->mountpath,
              mode == UFSD_MOUNT_RW ? "RW" : "RO");
 
@@ -556,7 +556,7 @@ ufsd_ufs_init(UFSD_STC *stc)
 
     rc = ufsd_cfg_read(&cfg);
     if (rc != 0) {
-        wtof("UFSD061E Parmlib (DD:UFSDPRM) not found -- shutting down");
+        wtof("UFSD061E PARMLIB (DD:UFSDPRM) NOT FOUND -- SHUTTING DOWN");
         return 8;
     }
 
@@ -566,7 +566,7 @@ ufsd_ufs_init(UFSD_STC *stc)
     rc = ufsd_disk_mount_dyn(stc, cfg.root_dsname, "/",
                              UFSD_MOUNT_RW, "");
     if (rc != 0) {
-        wtof("UFSD061E Cannot mount root filesystem -- shutting down");
+        wtof("UFSD061E CANNOT MOUNT ROOT FILESYSTEM -- SHUTTING DOWN");
         return 8;
     }
 
@@ -610,26 +610,26 @@ ufsd_ufs_init(UFSD_STC *stc)
         pdisk->mount_mode = saved_mode;
 
         if (rc != UFSD_RC_OK && rc != UFSD_RC_EXIST)
-            wtof("UFSD122W Cannot create mount point %s (rc=%d)",
+            wtof("UFSD122W CANNOT CREATE MOUNT POINT %s (RC=%d)",
                  m->path, rc);
 
         /* Mount the child filesystem */
         rc = ufsd_disk_mount_dyn(stc, m->dsname, m->path,
                                  m->mode, m->owner);
         if (rc != 0)
-            wtof("UFSD123W Cannot mount DSN=%s on %s",
+            wtof("UFSD123W CANNOT MOUNT DSN=%s ON %s",
                  m->dsname, m->path);
     }
 
     /* Root is now RO for clients — all mountpoints are created */
     root->mount_mode = UFSD_MOUNT_RO;
 
-    wtof("UFSD040I %u filesystem(s) mounted", stc->ndisks);
+    wtof("UFSD040I %u FILESYSTEM(S) MOUNTED", stc->ndisks);
     for (i = 0; i < stc->ndisks; i++) {
         UFSD_DISK *d = stc->disks[i];
         if (!d) continue;
         if (d->flags & UFSD_DISK_ROOT)
-            wtof("UFSD041I   %s DSN=%s (root, %s)",
+            wtof("UFSD041I   %s DSN=%s (ROOT, %s)",
                  d->mountpath, d->dsn,
                  d->mount_mode == UFSD_MOUNT_RW ? "RW" : "RO");
         else if (d->mount_owner[0])
@@ -668,10 +668,10 @@ ufsd_ufs_term(UFSD_STC *stc)
         if ((d->flags & UFSD_DISK_OPEN) &&
             !(d->flags & UFSD_DISK_RDONLY)) {
             if (ufsd_sb_write(d))
-                wtof("UFSD130W Superblock writeback failed for DSN=%s",
+                wtof("UFSD130W SUPERBLOCK WRITEBACK FAILED FOR DSN=%s",
                      d->dsn);
             else
-                wtof("UFSD131I Superblock written for DSN=%s", d->dsn);
+                wtof("UFSD131I SUPERBLOCK WRITTEN FOR DSN=%s", d->dsn);
         }
         /* Save ddname before close_disk frees the struct */
         memcpy(ddname, d->ddname, 9);
@@ -701,7 +701,7 @@ ufsd_disk_umount(UFSD_STC *stc, const char *mountpath)
     if (!stc || !mountpath) return 8;
 
     if (mountpath[0] == '/' && mountpath[1] == '\0') {
-        wtof("UFSD132E UNMOUNT: cannot unmount root filesystem");
+        wtof("UFSD132E UNMOUNT: CANNOT UNMOUNT ROOT FILESYSTEM");
         return 8;
     }
 
@@ -715,21 +715,21 @@ ufsd_disk_umount(UFSD_STC *stc, const char *mountpath)
     }
 
     if (found < 0) {
-        wtof("UFSD133E UNMOUNT: no filesystem mounted on %s", mountpath);
+        wtof("UFSD133E UNMOUNT: NO FILESYSTEM MOUNTED ON %s", mountpath);
         return 8;
     }
 
     disk = stc->disks[found];
-    wtof("UFSD064I Unmounting %s from %s", disk->dsn, disk->mountpath);
+    wtof("UFSD064I UNMOUNTING %s FROM %s", disk->dsn, disk->mountpath);
 
     /* Write superblock back to disk for RW filesystems */
     if ((disk->flags & UFSD_DISK_OPEN) &&
         !(disk->flags & UFSD_DISK_RDONLY)) {
         if (ufsd_sb_write(disk))
-            wtof("UFSD130W Superblock writeback failed for DSN=%s",
+            wtof("UFSD130W SUPERBLOCK WRITEBACK FAILED FOR DSN=%s",
                  disk->dsn);
         else
-            wtof("UFSD131I Superblock written for DSN=%s", disk->dsn);
+            wtof("UFSD131I SUPERBLOCK WRITTEN FOR DSN=%s", disk->dsn);
     }
 
     /* Save ddname, close, DYNFREE if applicable */

--- a/src/ufsd#que.c
+++ b/src/ufsd#que.c
@@ -106,7 +106,7 @@ ufsd_dispatch(UFSD_ANCHOR *anchor, UFSREQ *req)
 
     /* --- Eye-catcher check --- */
     if (memcmp(req->eye, "UFSREQ__", 8) != 0) {
-        wtof("UFSD150E Corrupt request block (eye catcher mismatch)");
+        wtof("UFSD150E CORRUPT REQUEST BLOCK (EYE CATCHER MISMATCH)");
         ufsd_trace(anchor, UFSD_T_CORRUPT, 0, (unsigned short)UFSD_RC_CORRUPT);
         /* Write error stat and post client ECB (key 0 for CSA write) */
         if (!__super(PSWKEY0, &savekey)) {
@@ -120,7 +120,7 @@ ufsd_dispatch(UFSD_ANCHOR *anchor, UFSREQ *req)
 
     /* --- Function code check --- */
     if (req->func < UFSREQ_MIN || req->func > UFSREQ_MAX) {
-        wtof("UFSD151E Invalid function code %04X", req->func);
+        wtof("UFSD151E INVALID FUNCTION CODE %04X", req->func);
         ufsd_trace(anchor, UFSD_T_BADFUNC, req->session_token,
                    (unsigned short)UFSD_RC_BADFUNC);
         if (!__super(PSWKEY0, &savekey)) {

--- a/src/ufsd#sbl.c
+++ b/src/ufsd#sbl.c
@@ -70,7 +70,7 @@ ufsd_sb_read(UFSD_DISK *disk)
         || disk->sb.nfreeblock > UFSD_SB_MAX_FREEBLOCK
         || disk->sb.nfreeinode > UFSD_SB_MAX_FREEINODE
         || disk->sb.ilist_sector != 2) {
-        wtof("UFSD062E Superblock validation failed for %s", disk->dsn);
+        wtof("UFSD062E SUPERBLOCK VALIDATION FAILED FOR %s", disk->dsn);
         return UFSD_RC_CORRUPT;
     }
 
@@ -274,8 +274,8 @@ inode_scan_refill(UFSD_DISK *disk)
 
     if (found > 0) {
         disk->sb.total_freeinode = found;
-        wtof("UFSD076I Free inode scan: found %u inodes "
-             "(cache refilled to %u)", found, disk->sb.nfreeinode);
+        wtof("UFSD076I FREE INODE SCAN: FOUND %u INODES "
+             "(CACHE REFILLED TO %u)", found, disk->sb.nfreeinode);
         return UFSD_RC_OK;
     }
 
@@ -446,8 +446,8 @@ sb_scan_refill(UFSD_DISK *disk)
     free(used);
 
     if (found > 0) {
-        wtof("UFSD070I Free block scan: found %u blocks "
-             "(cache refilled to %u)", found, disk->sb.nfreeblock);
+        wtof("UFSD070I FREE BLOCK SCAN: FOUND %u BLOCKS "
+             "(CACHE REFILLED TO %u)", found, disk->sb.nfreeblock);
         return UFSD_RC_OK;
     }
 

--- a/src/ufsd#sct.c
+++ b/src/ufsd#sct.c
@@ -28,14 +28,14 @@ ufsd_ssct_init(UFSD_ANCHOR *anchor)
     int             rc;
 
     if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD091E Cannot enter supervisor state for SSCT init");
+        wtof("UFSD091E CANNOT ENTER SUPERVISOR STATE FOR SSCT INIT");
         return -1;
     }
 
     ssvt = ssvt_new(UFSREQ_MAX);
     if (!ssvt) {
         __prob(savekey, NULL);
-        wtof("UFSD093E Cannot allocate SSVT");
+        wtof("UFSD093E CANNOT ALLOCATE SSVT");
         return -1;
     }
 
@@ -43,7 +43,7 @@ ufsd_ssct_init(UFSD_ANCHOR *anchor)
     if (!ssct) {
         ssvt_free(ssvt);
         __prob(savekey, NULL);
-        wtof("UFSD094E Cannot allocate SSCT");
+        wtof("UFSD094E CANNOT ALLOCATE SSCT");
         return -1;
     }
 
@@ -52,7 +52,7 @@ ufsd_ssct_init(UFSD_ANCHOR *anchor)
         ssct_free(ssct);
         ssvt_free(ssvt);
         __prob(savekey, NULL);
-        wtof("UFSD097E Cannot install SSCT, RC=%d", rc);
+        wtof("UFSD025E CANNOT INSTALL SSCT, RC=%d", rc);
         return -1;
     }
 
@@ -86,14 +86,14 @@ ufsd_ssi_load(UFSD_ANCHOR *anchor)
     if (!anchor || !anchor->ssvt) return -1;
 
     if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD098E Cannot enter supervisor for SSI load");
+        wtof("UFSD026E CANNOT ENTER SUPERVISOR FOR SSI LOAD");
         return -1;
     }
 
     rc = __loadhi("UFSDSSIR", &lpa, &epa, &size);
     if (rc) {
         __prob(savekey, NULL);
-        wtof("UFSD098E Cannot load UFSDSSIR into CSA, RC=%d", rc);
+        wtof("UFSD027E CANNOT LOAD UFSDSSIR INTO CSA, RC=%d", rc);
         return -1;
     }
 

--- a/src/ufsd#ses.c
+++ b/src/ufsd#ses.c
@@ -56,7 +56,7 @@ ufsd_sess_init(UFSD_ANCHOR *anchor)
     sessions = (UFSD_SESSION *)calloc(UFSD_MAX_SESSIONS,
                                       sizeof(UFSD_SESSION));
     if (!sessions) {
-        wtof("UFSD045E Cannot allocate session table");
+        wtof("UFSD045E CANNOT ALLOCATE SESSION TABLE");
         return 8;
     }
 
@@ -73,7 +73,7 @@ ufsd_sess_init(UFSD_ANCHOR *anchor)
     /* Store pointer in CSA anchor (key-0 write) */
     if (__super(PSWKEY0, &savekey)) {
         free(sessions);
-        wtof("UFSD046E Cannot enter supervisor state for session init");
+        wtof("UFSD046E CANNOT ENTER SUPERVISOR STATE FOR SESSION INIT");
         return 8;
     }
     anchor->sessions     = sessions;
@@ -197,7 +197,7 @@ ufsd_sess_open(UFSD_ANCHOR *anchor, UFSREQ *req, unsigned *out_token)
     /* Allocate per-session UFS handle */
     ufs = (UFSD_UFS *)calloc(1, sizeof(UFSD_UFS));
     if (!ufs) {
-        wtof("UFSD070E Cannot allocate UFS handle");
+        wtof("UFSD070E CANNOT ALLOCATE UFS HANDLE");
         return UFSD_RC_NOREQ;
     }
     memcpy(ufs->eye, "UFSD_UFS", 8);
@@ -344,7 +344,7 @@ ufsd_sess_list(UFSD_ANCHOR *anchor)
         }
 
         wtof("UFSD051I   #%u TOKEN=%08X ASID=%04X"
-             " OWNER=%-8.8s GROUP=%-8.8s FDs=%u/%u",
+             " OWNER=%-8.8s GROUP=%-8.8s FDS=%u/%u",
              i + 1U,
              sess->token,
              sess->client_asid,
@@ -418,8 +418,8 @@ ufsd_sess_cleanup(UFSD_ANCHOR *anchor)
             sess->ufs = NULL;
         }
 
-        wtof("UFSD052I CLEANUP: session #%u TOKEN=%08X ASID=%04X"
-             " (%.8s) released",
+        wtof("UFSD052I CLEANUP: SESSION #%u TOKEN=%08X ASID=%04X"
+             " (%.8s) RELEASED",
              i + 1U, sess->token, asid,
              sess->owner[0] ? sess->owner : "(none)");
 

--- a/src/ufsd#trc.c
+++ b/src/ufsd#trc.c
@@ -79,7 +79,7 @@ ufsd_trace_dump(UFSD_ANCHOR *anchor)
     unsigned    count;
 
     if (!anchor || !anchor->trace_buf) {
-        wtof("UFSD080W TRACE DUMP: trace buffer not available");
+        wtof("UFSD080W TRACE DUMP: TRACE BUFFER NOT AVAILABLE");
         return;
     }
 
@@ -91,7 +91,7 @@ ufsd_trace_dump(UFSD_ANCHOR *anchor)
         count++;
     }
 
-    wtof("UFSD080I TRACE DUMP: %u entr%s", count,
+    wtof("UFSD080I TRACE DUMP: %u ENTR%s", count,
          count == 1 ? "y" : "ies");
 
     count = 0;

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -78,7 +78,7 @@ ufsd_recover(SDWA *sdwa)
 
     ufsd = (UFSD_STC *)sdwa->SDWAPARM;
 
-    wtof("UFSD098E UFSD abend intercepted -- emergency shutdown");
+    wtof("UFSD098E UFSD ABEND INTERCEPTED -- EMERGENCY SHUTDOWN");
 
     if (ufsd) {
         ufsd->flags &= ~UFSD_ACTIVE;
@@ -162,8 +162,8 @@ ufsd_shutdown(UFSD_STC *ufsd, int mode)
         ** Clearing ANCHOR_ACTIVE alone does not stop that; only the SSVT
         ** entry does.  Same order as UFSDCLNP. */
         if (__super(PSWKEY0, &savekey)) {
-            wtof("UFSD097E Cannot enter supervisor state -- "
-                 "CSA retained, run UFSDCLNP before restart");
+            wtof("UFSD097E CANNOT ENTER SUPERVISOR STATE -- "
+                 "CSA RETAINED, RUN UFSDCLNP BEFORE RESTART");
             ufsd_ufs_term(ufsd);
             return;                       /* free nothing */
         }
@@ -186,15 +186,15 @@ ufsd_shutdown(UFSD_STC *ufsd, int mode)
         /* Under RTM we cannot drain and must not free: a foreign PSW may
         ** still be executing inside UFSDSSIR or touching the pools.
         ** Leave everything and percolate; UFSDCLNP reclaims on restart. */
-        wtof("UFSD097W Abend shutdown -- CSA retained, "
-             "run UFSDCLNP before restart");
+        wtof("UFSD097W ABEND SHUTDOWN -- CSA RETAINED, "
+             "RUN UFSDCLNP BEFORE RESTART");
         goto done;
     }
 
     /* Step 4: drain in-flight clients out of the router. */
     if (!ufsd_drain(anchor)) {
-        wtof("UFSD098W %u client(s) still in flight -- CSA retained, "
-             "run UFSDCLNP before restart", anchor->inflight);
+        wtof("UFSD098W %u CLIENT(S) STILL IN FLIGHT -- CSA RETAINED, "
+             "RUN UFSDCLNP BEFORE RESTART", anchor->inflight);
         goto done;                        /* free nothing */
     }
 
@@ -203,27 +203,27 @@ ufsd_shutdown(UFSD_STC *ufsd, int mode)
     ** the tables, pools, and finally the anchor. */
     if (anchor->ssct) {
         ufsd_ssct_free(anchor);
-        wtof("UFSD095I SSCT deregistered");
+        wtof("UFSD095I SSCT DEREGISTERED");
     }
     if (anchor->ssir_lpa) {
         ufsd_ssi_unload(anchor);
-        wtof("UFSD036I SSI router unloaded");
+        wtof("UFSD036I SSI ROUTER UNLOADED");
     }
     if (anchor->gfiles) {
         ufsd_gft_free(anchor);
-        wtof("UFSD048I Global file table freed");
+        wtof("UFSD048I GLOBAL FILE TABLE FREED");
     }
     if (anchor->sessions) {
         ufsd_sess_free(anchor);
-        wtof("UFSD046I Session table freed");
+        wtof("UFSD046I SESSION TABLE FREED");
     }
     ufsd_csa_free(anchor);
-    wtof("UFSD096I CSA freed");
+    wtof("UFSD096I CSA FREED");
     ufsd_anchor_free(anchor);             /* clears the eye catcher first */
     ufsd->anchor = NULL;
 
 done:
-    wtof("UFSD099I UFSD shutdown complete");
+    wtof("UFSD099I UFSD SHUTDOWN COMPLETE");
 }
 
 int
@@ -247,7 +247,7 @@ main(int argc, char **argv)
     /* --- Console interface ---------------------------------------- */
     com = __gtcom();
     if (!com) {
-        wtof("UFSD090E Unable to initialize console interface");
+        wtof("UFSD090E UNABLE TO INITIALIZE CONSOLE INTERFACE");
         return 8;
     }
 
@@ -257,7 +257,7 @@ main(int argc, char **argv)
     /* --- APF authorization --------------------------------------- */
     rc = clib_apf_setup(argv[0]);
     if (rc) {
-        wtof("UFSD091E APF setup failed RC=%d (STEPLIB not APF authorized?)",
+        wtof("UFSD091E APF SETUP FAILED RC=%d (STEPLIB NOT APF AUTHORIZED?)",
              rc);
         return 8;
     }
@@ -265,12 +265,12 @@ main(int argc, char **argv)
     /* --- ESTAE recovery ------------------------------------------ */
     __estae(ESTAE_CREATE, ufsd_recover, &ufsd);
 
-    wtof("UFSD000I UFSD %s starting", VERSION);
+    wtof("UFSD000I UFSD %s STARTING", VERSION);
 
     /* --- CSA anchor ---------------------------------------------- */
     anchor = ufsd_anchor_alloc();
     if (!anchor) {
-        wtof("UFSD092E Cannot allocate CSA anchor");
+        wtof("UFSD092E CANNOT ALLOCATE CSA ANCHOR");
         return 8;
     }
     ufsd.anchor = anchor;
@@ -293,14 +293,14 @@ main(int argc, char **argv)
         }
     }
 
-    wtof("UFSD030I CSA allocated: Anchor=%08X", (unsigned)anchor);
-    wtof("UFSD031I   Request Pool: %u blocks, %uK",
+    wtof("UFSD030I CSA ALLOCATED: ANCHOR=%08X", (unsigned)anchor);
+    wtof("UFSD031I   REQUEST POOL: %u BLOCKS, %uK",
          (unsigned)UFSD_REQ_POOL_COUNT,
          (UFSD_REQ_POOL_COUNT * (unsigned)sizeof(UFSREQ) + 511U) / 1024U);
-    wtof("UFSD032I   Buffer Pool:  %u blocks, %uK",
+    wtof("UFSD032I   BUFFER POOL:  %u BLOCKS, %uK",
          (unsigned)UFSD_BUF_POOL_COUNT,
          (UFSD_BUF_POOL_COUNT * (unsigned)sizeof(UFSBUF) + 511U) / 1024U);
-    wtof("UFSD033I   Trace Buffer: %u entries, %uK",
+    wtof("UFSD033I   TRACE BUFFER: %u ENTRIES, %uK",
          (unsigned)UFSD_TRACE_SIZE,
          (UFSD_TRACE_SIZE * (unsigned)sizeof(UFSD_TRACE) + 511U) / 1024U);
 
@@ -312,7 +312,7 @@ main(int argc, char **argv)
         ufsd.anchor = NULL;
         return 8;
     }
-    wtof("UFSD034I SSCT registered, subsystem name=UFSD");
+    wtof("UFSD034I SSCT REGISTERED, SUBSYSTEM NAME=UFSD");
 
     /* --- SSI router ------------------------------------------ */
     rc = ufsd_ssi_load(anchor);
@@ -323,7 +323,7 @@ main(int argc, char **argv)
         ufsd.anchor = NULL;
         return 8;
     }
-    wtof("UFSD035I SSI router loaded at %08X", (unsigned)anchor->ssir_lpa);
+    wtof("UFSD035I SSI ROUTER LOADED AT %08X", (unsigned)anchor->ssir_lpa);
 
     /* --- Session table (AP-1d) ----------------------------------- */
     rc = ufsd_sess_init(anchor);
@@ -335,7 +335,7 @@ main(int argc, char **argv)
         ufsd.anchor = NULL;
         return 8;
     }
-    wtof("UFSD045I Session table: %u slots", (unsigned)UFSD_MAX_SESSIONS);
+    wtof("UFSD045I SESSION TABLE: %u SLOTS", (unsigned)UFSD_MAX_SESSIONS);
 
     /* --- Global file table (AP-1e) --------------------------------- */
     rc = ufsd_gft_init(anchor);
@@ -348,7 +348,7 @@ main(int argc, char **argv)
         ufsd.anchor = NULL;
         return 8;
     }
-    wtof("UFSD047I Global file table: %u slots", (unsigned)UFSD_MAX_GFILES);
+    wtof("UFSD047I GLOBAL FILE TABLE: %u SLOTS", (unsigned)UFSD_MAX_GFILES);
 
     /* --- UFS disk init (AP-1d Step 2) ----------------------------- */
     rc = ufsd_ufs_init(&ufsd);
@@ -364,8 +364,8 @@ main(int argc, char **argv)
              (UFSD_BUF_POOL_COUNT * (unsigned)sizeof(UFSBUF)) +
              (UFSD_TRACE_SIZE * (unsigned)sizeof(UFSD_TRACE)) +
              (unsigned)sizeof(UFSD_ANCHOR) + 1023U) / 1024U;
-        wtof("UFSD001I UFSD %s ready -- %u disks, %uK CSA, "
-             "%u sessions, %u files",
+        wtof("UFSD001I UFSD %s READY -- %u DISKS, %uK CSA, "
+             "%u SESSIONS, %u FILES",
              VERSION, ufsd.ndisks, csa_kb,
              (unsigned)UFSD_MAX_SESSIONS, (unsigned)UFSD_MAX_GFILES);
     }

--- a/src/ufsdclnp.c
+++ b/src/ufsdclnp.c
@@ -83,19 +83,19 @@ main(int argc, char **argv)
 
     (void)argc;
 
-    wtof("UFSD140I UFSDCLNP starting");
+    wtof("UFSD140I UFSDCLNP STARTING");
 
     /* --- APF authorization (required for key-0 and SSCT ops) --- */
     rc = clib_apf_setup(argv[0]);
     if (rc) {
-        wtof("UFSD141E UFSDCLNP: APF setup failed RC=%d", rc);
+        wtof("UFSD141E UFSDCLNP: APF SETUP FAILED RC=%d", rc);
         return 8;
     }
 
     /* --- Locate UFSD subsystem --- */
     ssct = ssct_find("UFSD");
     if (!ssct) {
-        wtof("UFSD142I UFSDCLNP: subsystem UFSD not registered");
+        wtof("UFSD142I UFSDCLNP: SUBSYSTEM UFSD NOT REGISTERED");
         return 0;
     }
 
@@ -111,13 +111,13 @@ main(int argc, char **argv)
     ** "eye still valid" bail path, so clearing the eye now would strand the
     ** counter and defeat the drain in step 2. */
     if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD143E UFSDCLNP: cannot enter supervisor state");
+        wtof("UFSD143E UFSDCLNP: CANNOT ENTER SUPERVISOR STATE");
         return 8;
     }
     if (ssvt) {
         ssvt_reset(ssvt, UFSD_SSVT_ROUTER);
         ssvt_funcmap(ssvt, 0, UFSD_SSOBFUNC);
-        wtof("UFSD144I UFSDCLNP: SSVT function pointer cleared");
+        wtof("UFSD144I UFSDCLNP: SSVT FUNCTION POINTER CLEARED");
     }
     if (anchor_ok)
         anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
@@ -130,8 +130,8 @@ main(int argc, char **argv)
     ** leaked and freed anyway (see file header). */
     if (anchor_ok && anchor->inflight) {
         if (!ufsdclnp_drain(anchor))
-            wtof("UFSD146W UFSDCLNP: %u client(s) still in flight after "
-                 "drain -- assuming leaked, freeing", anchor->inflight);
+            wtof("UFSD152W UFSDCLNP: %u CLIENT(S) STILL IN FLIGHT AFTER "
+                 "DRAIN -- ASSUMING LEAKED, FREEING", anchor->inflight);
     }
 
     /* --- Step 3: tear down under key-0 -- deregister the SSCT (frees the
@@ -139,21 +139,21 @@ main(int argc, char **argv)
     ** Order matters: the module references the pool blocks, so it goes
     ** first; the anchor goes last. */
     if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD143E UFSDCLNP: cannot enter supervisor state");
+        wtof("UFSD143E UFSDCLNP: CANNOT ENTER SUPERVISOR STATE");
         return 8;
     }
 
     ssct_remove(ssct);
     ssct_free(ssct);
     if (ssvt) ssvt_free(ssvt);
-    wtof("UFSD145I UFSDCLNP: SSCT deregistered");
+    wtof("UFSD145I UFSDCLNP: SSCT DEREGISTERED");
 
     if (anchor_ok) {
         /* Free UFSDSSIR CSA load module */
         if (anchor->ssir_lpa) {
             freemain(anchor->ssir_lpa);
             anchor->ssir_lpa = NULL;
-            wtof("UFSD146I UFSDCLNP: SSI router module freed");
+            wtof("UFSD146I UFSDCLNP: SSI ROUTER MODULE FREED");
         }
 
         /* Free trace ring buffer */
@@ -176,23 +176,23 @@ main(int argc, char **argv)
             anchor->free_head     = NULL;
         }
 
-        wtof("UFSD147I UFSDCLNP: CSA pools freed");
+        wtof("UFSD147I UFSDCLNP: CSA POOLS FREED");
 
         /* Invalidate the eye catcher BEFORE the FREEMAIN so a client still
         ** in the drain settle window bails on eye-mismatch instead of
         ** trusting a live-looking anchor.  Anchor goes last. */
         memset(anchor->eye, 0, sizeof(anchor->eye));
         freemain(anchor);
-        wtof("UFSD148I UFSDCLNP: anchor freed");
+        wtof("UFSD148I UFSDCLNP: ANCHOR FREED");
     } else if (anchor) {
-        wtof("UFSD148W UFSDCLNP: anchor eye mismatch at %08X",
+        wtof("UFSD153W UFSDCLNP: ANCHOR EYE MISMATCH AT %08X",
              (unsigned)anchor);
     } else {
-        wtof("UFSD148I UFSDCLNP: no anchor (ssctsuse=NULL)");
+        wtof("UFSD154I UFSDCLNP: NO ANCHOR (SSCTSUSE=NULL)");
     }
 
     __prob(savekey, NULL);
 
-    wtof("UFSD149I UFSDCLNP complete");
+    wtof("UFSD149I UFSDCLNP COMPLETE");
     return 0;
 }


### PR DESCRIPTION
## Summary

Pre-release cleanup of the UFSD console (`wtof`) messages — three parts.
Closes #42.

### 1. Unique message IDs

Reassigned the IDs that were reused for more than one distinct message:

| Was | Now | Message |
|-----|-----|---------|
| `UFSD097E` (sct) | `UFSD025E` | Cannot install SSCT, RC=%d |
| `UFSD098E` (sct) | `UFSD026E` | Cannot enter supervisor for SSI load |
| `UFSD098E` (sct) | `UFSD027E` | Cannot load UFSDSSIR into CSA, RC=%d |
| `UFSD146W` (clnp) | `UFSD152W` | client(s) still in flight … assuming leaked, freeing |
| `UFSD148W` (clnp) | `UFSD153W` | anchor eye mismatch |
| `UFSD148I` (clnp, 2nd use) | `UFSD154I` | no anchor (ssctsuse=NULL) |

The shutdown `097E`/`097W`/`098E`/`098W` family and UFSDCLNP `146I`/`148I`
keep their numbers and are now unambiguous.

*Out of scope (pre-existing, intentional groupings, left as-is):* the
multi-line `UFSD020I` HELP output and the `UFSD021E` command-usage-error
family, plus a few informational variants (`041I`, `060I`, `061E`, …) that
share an ID by design.

### 2. Upper-case message text

All `wtof()` message text is upper-cased (MVS operator-console convention),
applied with a script that **preserves**:

- `printf` format specifiers — `%s`, `%u`, `%d`, `%04X`, `%08X`, `%.8s`,
  `%-12s`, `%-20s`, `%-2s`, `%.40s`, `%-44s`, `%3u` (verified: no conversion
  letter was altered).
- The operator-supplied value placeholders in the `/F UFSD,HELP` and syntax
  messages — `dsn`, `/path`, `user` — kept lower-case "as given".

### 3. `inflight` in `/F UFSD,STATS`

Added `UFSD016I IN FLIGHT: n` to the STATS output so an operator can see how
many SSI clients are currently executing in the router (the counter added for
#30/#39).

### Docs

`docs/recovery.md` (WTO reference tables + the shutdown and UFSDCLNP console
examples, now upper-case with the new IDs), `docs/concept.md` and
`docs/configuration.md` (STATS field lists) updated to match.

### Verification

`make` builds all three modules clean under `cc370 -Wall -Werror` — the key
check that no format string was broken by the upper-casing. No `mbt` submodule
change is included.
