### PR TITLE
Fail the mount and the block scan instead of degrading silently (#44)

### DIFF
--- a/src/ufsd#fil.c
+++ b/src/ufsd#fil.c
@@ -282,8 +282,19 @@ blk_alloc_at(UFSD_DISK *disk, UFSD_DINODE *dino,
 }
 
 /* Free all data blocks of an inode, including indirect blocks.
-** Does NOT free the inode itself. */
-static void
+** Does NOT free the inode itself.
+**
+** Returns UFSD_RC_OK, or UFSD_RC_IO when the indirect block cannot be
+** read.  In that case addr[UFSD_NADDR_SINDIRECT] is deliberately left
+** intact and the indirect block itself is not freed: the data blocks
+** behind it stay reachable from the inode, so a MODIFY REBUILD scan
+** still counts them as used.  Freeing the indirect block and zeroing
+** the pointer is what would make them unreachable for good.
+**
+** Callers report the failure instead of continuing.  The direct blocks
+** freed before the failure are already in the superblock cache, and the
+** disk is left in a state MODIFY REBUILD reconciles. */
+static int
 blk_free_all(UFSD_DISK *disk, UFSD_DINODE *dino)
 {
     unsigned  i;
@@ -302,21 +313,27 @@ blk_free_all(UFSD_DISK *disk, UFSD_DINODE *dino)
     /* Free single indirect block and its data blocks */
     if (dino->addr[UFSD_NADDR_SINDIRECT] != 0) {
         ibuf = (char *)malloc(disk->blksize);
-        if (ibuf) {
-            if (ufsd_blk_read(disk, dino->addr[UFSD_NADDR_SINDIRECT], ibuf)
-                == UFSD_RC_OK) {
-                ind  = (unsigned *)ibuf;
-                nind = (unsigned)disk->blksize / 4U;
-                for (i = 0; i < nind; i++) {
-                    if (ind[i] != 0)
-                        ufsd_sb_free_block(disk, ind[i]);
-                }
-            }
+        if (!ibuf) return UFSD_RC_IO;
+
+        if (ufsd_blk_read(disk, dino->addr[UFSD_NADDR_SINDIRECT], ibuf)
+            != UFSD_RC_OK) {
             free(ibuf);
+            return UFSD_RC_IO;
         }
+
+        ind  = (unsigned *)ibuf;
+        nind = (unsigned)disk->blksize / 4U;
+        for (i = 0; i < nind; i++) {
+            if (ind[i] != 0)
+                ufsd_sb_free_block(disk, ind[i]);
+        }
+        free(ibuf);
+
         ufsd_sb_free_block(disk, dino->addr[UFSD_NADDR_SINDIRECT]);
         dino->addr[UFSD_NADDR_SINDIRECT] = 0;
     }
+
+    return UFSD_RC_OK;
 }
 
 /* ============================================================
@@ -528,7 +545,9 @@ do_rmdir(UFSD_STC *stc, UFSD_SESSION *sess,
     rc = ufsd_dir_remove(disk, parent_ino, dir_name);
     if (rc != UFSD_RC_OK) return rc;
 
-    blk_free_all(disk, &dino);
+    rc = blk_free_all(disk, &dino);
+    if (rc != UFSD_RC_OK) return rc;
+
     ufsd_sb_free_inode(disk, dir_ino);
 
     return ufsd_sb_write(disk);
@@ -637,7 +656,13 @@ do_remove(UFSD_STC *stc, UFSD_SESSION *sess,
 
     if (dino.nlink > 0) dino.nlink--;
     if (dino.nlink == 0) {
-        blk_free_all(disk, &dino);
+        /* The directory entry is already gone at this point.  Report the
+        ** failure anyway rather than claiming a clean unlink: the blocks
+        ** we could not release stay attributed to the inode until a
+        ** MODIFY REBUILD runs. */
+        rc = blk_free_all(disk, &dino);
+        if (rc != UFSD_RC_OK) return rc;
+
         ufsd_sb_free_inode(disk, file_ino);
     } else {
         ufsd_ino_write(disk, file_ino, &dino);
@@ -703,7 +728,11 @@ do_fopen(UFSD_STC *stc, UFSD_ANCHOR *anchor, UFSD_SESSION *sess,
             if ((dino.mode & UFSD_IFMT) == UFSD_IFDIR) return UFSD_RC_ISDIR;
             wrc = ufsd_check_write(disk, sess);
             if (wrc != UFSD_RC_OK) return wrc;
-            blk_free_all(disk, &dino);
+            /* Fail before the inode is stamped as empty: on error the
+            ** file keeps both its blocks and its size. */
+            rc = blk_free_all(disk, &dino);
+            if (rc != UFSD_RC_OK) return rc;
+
             dino.filesize = 0;
             ufsd_stamp(&dino);
             if (ufsd_ino_write(disk, file_ino, &dino) != UFSD_RC_OK)

--- a/src/ufsd#ini.c
+++ b/src/ufsd#ini.c
@@ -209,24 +209,32 @@ open_disk(const char *ddname)
     if (disk->blksize == 0)
         disk->blksize = 4096;       /* safe fallback */
 
-    /* Read and validate boot block (sector 0) */
+    /* Read and validate boot block (sector 0).
+    ** Without the buffer the magic check cannot run, so refuse the mount:
+    ** returning the handle anyway would mount an unverified dataset and
+    ** then write UFS metadata into it. */
     buf = (char *)calloc(1, (unsigned)disk->blksize);
-    if (buf) {
-        memset(&decb, 0, sizeof(decb));
-        osdread(&decb, dcb, buf, (int)disk->blksize, 0);
-        oscheck(&decb);
-
-        boot = (UFSBOOT_HDR *)buf;
-        if (boot->type != (unsigned short)UFSD_DISK_TYPE_UFS ||
-            (unsigned)(boot->type + boot->check) != 0xFFFFU) {
-            wtof("UFSD044E %s: NOT A VALID UFS DISK (TYPE=%04X)",
-                 disk->ddname, (unsigned)boot->type);
-            free(buf);
-            close_disk(disk);
-            return NULL;
-        }
-        free(buf);
+    if (!buf) {
+        wtof("UFSD049E %s: NO STORAGE FOR BOOT BLOCK (%u BYTES)",
+             disk->ddname, (unsigned)disk->blksize);
+        close_disk(disk);
+        return NULL;
     }
+
+    memset(&decb, 0, sizeof(decb));
+    osdread(&decb, dcb, buf, (int)disk->blksize, 0);
+    oscheck(&decb);
+
+    boot = (UFSBOOT_HDR *)buf;
+    if (boot->type != (unsigned short)UFSD_DISK_TYPE_UFS ||
+        (unsigned)(boot->type + boot->check) != 0xFFFFU) {
+        wtof("UFSD044E %s: NOT A VALID UFS DISK (TYPE=%04X)",
+             disk->ddname, (unsigned)boot->type);
+        free(buf);
+        close_disk(disk);
+        return NULL;
+    }
+    free(buf);
 
     return disk;
 }

--- a/src/ufsd#sbl.c
+++ b/src/ufsd#sbl.c
@@ -353,6 +353,8 @@ static int
 sb_scan_refill(UFSD_DISK *disk)
 {
     unsigned char *used;
+    char          *ibuf;
+    unsigned      *ind;
     unsigned       bitmap_bytes;
     unsigned       vol;
     unsigned       ipb;
@@ -370,6 +372,17 @@ sb_scan_refill(UFSD_DISK *disk)
     bitmap_bytes = (vol + 7U) / 8U;
     used = (unsigned char *)calloc(1U, bitmap_bytes);
     if (!used) return UFSD_RC_IO;
+
+    /* One indirect block buffer for the whole scan instead of one per
+    ** inode: fewer allocations, and no chance of running out of storage
+    ** half way through.  Both buffers are hard requirements — a scan that
+    ** cannot read an indirect block leaves the blocks it points to
+    ** unmarked, and those blocks then get handed out as free. */
+    ibuf = (char *)malloc(disk->blksize);
+    if (!ibuf) {
+        free(used);
+        return UFSD_RC_IO;
+    }
 
     /* Mark metadata blocks as used */
     /* Block 0 (boot) and block 1 (superblock) */
@@ -404,23 +417,24 @@ sb_scan_refill(UFSD_DISK *disk)
         /* Single indirect block + its entries */
         if (dino.addr[UFSD_NADDR_DIRECT] != 0
             && dino.addr[UFSD_NADDR_DIRECT] < vol) {
-            char     *ibuf;
-            unsigned *ind;
-
             blk = dino.addr[UFSD_NADDR_DIRECT];
             used[blk / 8U] |= (unsigned char)(1U << (blk % 8U));
 
-            ibuf = (char *)malloc(disk->blksize);
-            if (ibuf) {
-                if (ufsd_blk_read(disk, blk, ibuf) == UFSD_RC_OK) {
-                    ind = (unsigned *)ibuf;
-                    for (i = 0; i < (unsigned)disk->blksize / 4U; i++) {
-                        if (ind[i] != 0 && ind[i] < vol)
-                            used[ind[i] / 8U] |=
-                                (unsigned char)(1U << (ind[i] % 8U));
-                    }
-                }
+            /* No WTO here: alloc_block runs this scan on every write once
+            ** the cache is empty, and the cache stays empty after a
+            ** failure — a message would repeat per request.  The operator
+            ** path reports it once (UFSD075E from MODIFY REBUILD). */
+            if (ufsd_blk_read(disk, blk, ibuf) != UFSD_RC_OK) {
                 free(ibuf);
+                free(used);
+                return UFSD_RC_IO;
+            }
+
+            ind = (unsigned *)ibuf;
+            for (i = 0; i < (unsigned)disk->blksize / 4U; i++) {
+                if (ind[i] != 0 && ind[i] < vol)
+                    used[ind[i] / 8U] |=
+                        (unsigned char)(1U << (ind[i] % 8U));
             }
         }
     }
@@ -443,6 +457,7 @@ sb_scan_refill(UFSD_DISK *disk)
     ** (Not persisted to disk — only valid for this session.) */
     disk->sb.unused3 = i;
 
+    free(ibuf);
     free(used);
 
     if (found > 0) {
@@ -471,7 +486,12 @@ ufsd_sb_rebuild_free(UFSD_DISK *disk)
 
     if (!disk) return UFSD_RC_IO;
 
-    /* Rebuild free block cache */
+    /* Rebuild free block cache.  When the scan gives up it does so before
+    ** touching the cache, which leaves nfreeblock at the 0 set here: the
+    ** in-memory cache is empty and nothing is written to disk, so the
+    ** superblock on the volume keeps the map it had.  Allocations fail
+    ** with NOSPACE until the next successful scan — safe, and far better
+    ** than persisting a map built from a partial scan. */
     disk->sb.nfreeblock = 0;
     disk->sb.unused3    = 0;  /* reset scan position */
     rc = sb_scan_refill(disk);


### PR DESCRIPTION
Closes #44.

Three error paths were dead code while `malloc()` could not fail. Since libc370#82 they are live, and all three continued as if nothing had happened.

## The three sites

**`src/ufsd#ini.c` — `open_disk`.** The `if (buf)` wrapped the *entire* boot block validation, so a failed `calloc` skipped the magic check and returned the handle as valid: a non-UFS dataset could be mounted and written to. Now refuses the mount with `UFSD049E`, using `close_disk` rather than `free(disk)` because the DCB is open at that point.

**`src/ufsd#sbl.c` — `sb_scan_refill`.** The indirect block buffer was allocated once per inode *inside* the scan loop, and the failure was ignored — the blocks behind an indirect block stayed unmarked, landed in `freeblock[]` and were handed out again, and `ufsd_sb_rebuild_free` persisted that map. The buffer is now allocated once for the whole scan and both allocations are hard requirements. The early return happens before `nfreeblock = 0`, so the existing cache survives a failed scan.

**`src/ufsd#fil.c` — `blk_free_all`.** Returns `int` now (it is `static`, so no header churn). The important part is not the return value: on failure `addr[UFSD_NADDR_SINDIRECT]` is deliberately left intact and the indirect block is *not* freed. Freeing it and zeroing the pointer is exactly what made the data blocks unreachable; leaving it keeps them attributed to the inode, so a `MODIFY REBUILD` scan still counts them as used. The three callers report the failure, and the truncate path in `do_fopen` returns before the inode is stamped as empty, so nothing is lost there.

## Two decisions beyond the issue

**The `ufsd_blk_read` beside each failing allocation is hardened the same way.** The issue names only the `malloc`s, but the read one line over is the identical silent skip with the identical consequence. In `sb_scan_refill` the two are also coupled: hoisting the buffer out of the loop without hardening the read would let a failed read leave the previous iteration's block numbers in the buffer.

**That changes behaviour in `sb_scan_refill`:** an unreadable indirect block now stops block allocation on that volume (NOSPACE) until `MODIFY REBUILD` runs, instead of continuing and handing out blocks that are in use. Conservative and in line with the issue's principle, but it is a decision worth pushing back on if you disagree.

No WTO was added on that path: `alloc_block` runs the scan on every write once the cache is empty, and the cache stays empty after a failure, so a message there would repeat per request. The operator path already reports it once via the existing `UFSD075E ... FAILED RC=%d`.

## Testing

**No automated regression test.** The toolchain cannot inject an allocation failure, and there is no host harness for server internals — the only test is the client-side `LIBUFTST` against a running server. A forced-NULL build would prove compilation and nothing else. Stating the gap rather than papering over it.

Verified live on mvsdev instead, deployed and activated into `UFSD.LINKLIB`:

| Changed path | How it was exercised | Result |
|---|---|---|
| `open_disk` restructure | 3 mounts at startup | boot block validation still passes on 3 real UFS disks (`UFSD040I`) -- the new refusal path did not run |
| `sb_scan_refill` | `F UFSD,REBUILD` over 3 real filesystems | free block cache 46/49/6 -> 51/51/51 (`UFSD_SB_MAX_FREEBLOCK`), no errors |
| `blk_free_all` via `do_remove` / `do_rmdir` / `do_fopen` | `LIBUFTST` (`REMOVE`, `RMDIR`, `FOPEN write`) | batch + TSO both CC 0 |

What that covers is the happy paths — i.e. the actual regression risk of this change. The allocation-failure branches themselves remain unexercised.

## Unrelated findings while deploying

- **Correction:** an earlier version of this section called the STEPLIB name in `docs/installation.md` wrong. It is not. `UFSD.V1R0M0.LINKLIB` there is an example DSN -- line 117 says "replace with the DSN you actually restored to" -- and this stand simply restored the XMIT elsewhere (`UFSD.LINKLIB`). No doc bug.
- A `VERSION` bump does not invalidate objects compiled with `-DVERSION`, so `ufsd.o` kept a stale string and the startup banner reported `1.0.0-dev` from a `1.1.0-dev` tree, while every other module was current. The banner is unreliable as a "which build is running" check. Documented in #48; the underlying dependency gap is an mbt change.
- `UFSD.LINKLIB` had no headroom (`IEB144I ... 0000000 UNUSED TRACKS`), so every activation depended on the compress step. Already resolved -- the library has been reallocated larger.

The activation job used to deploy this PR is #48.
