### PR TITLE
Release the server handle when the client-side allocation fails (#45)

### DIFF
--- a/client/libufs.c
+++ b/client/libufs.c
@@ -98,6 +98,34 @@ path_req(unsigned func, unsigned token, const char *path)
 }
 
 /* ============================================================
+** release_req
+**
+** Hand a server-side resource back on a failure path: SESS_CLOSE
+** (handle_len 0) or DIRCLOSE/FCLOSE (handle_len 4).  Both session
+** and file slots are finite server-side, so dropping one without
+** this leaks it until the server restarts.
+**
+** Best effort by design: the caller is already returning an error
+** and has nothing useful to do with a second failure.
+** ============================================================ */
+static void
+release_req(unsigned func, unsigned token,
+            unsigned handle, unsigned handle_len)
+{
+    UFSSSOB  ufsssob;
+
+    memset(&ufsssob, 0, sizeof(ufsssob));
+    memcpy(ufsssob.eye, UFSSSOB_EYE, 4);
+    ufsssob.func     = func;
+    ufsssob.token    = token;
+    if (handle_len == 4U)
+        *(unsigned *)ufsssob.data = handle;
+    ufsssob.data_len = handle_len;
+
+    libufs_issue(&ufsssob);
+}
+
+/* ============================================================
 ** Session lifecycle
 ** ============================================================ */
 
@@ -118,7 +146,13 @@ ufsnew(void)
     if (ufsssob.data_len < (unsigned)sizeof(unsigned)) return NULL;
 
     ufs = (UFS *)calloc(1, sizeof(UFS));
-    if (!ufs) return NULL;
+    if (!ufs) {
+        /* SESS_OPEN already took one of the server's finite session
+        ** slots.  Give it back -- nothing else ever will, the token
+        ** only existed in the response we are about to discard. */
+        release_req(UFSREQ_SESS_CLOSE, *(unsigned *)ufsssob.data, 0U, 0U);
+        return NULL;
+    }
 
     memcpy(ufs->eye,      "LIBUFSUFS", 8);
     ufs->token        = *(unsigned *)ufsssob.data;
@@ -407,6 +441,27 @@ dirlist_cmp(const void *a, const void *b)
     return strcmp(ea->name, eb->name);
 }
 
+/* ============================================================
+** diropen_fail
+**
+** Roll back a half-built directory descriptor: close the server
+** handle, free whatever was allocated locally, and record why via
+** ufs_last_rc -- ftpd's LIST handler reports from it, so leaving
+** it at the value of some earlier call would name the wrong error.
+**
+** Always returns NULL so callers can "return diropen_fail(...)".
+** ddesc and entries may be NULL.
+** ============================================================ */
+static UFSDDESC *
+diropen_fail(UFS *ufs, UFSDDESC *ddesc, UFSDLIST *entries, unsigned fd)
+{
+    release_req(UFSREQ_DIRCLOSE, ufs->token, fd, 4U);
+    if (entries) free(entries);
+    if (ddesc)   free(ddesc);
+    ufs->last_rc = UFSD_RC_IO;
+    return NULL;
+}
+
 /* Read one raw DIRREAD entry from the server, populate a UFSDLIST */
 static int
 dirread_one(UFSDDESC *ddesc, UFSDLIST *out)
@@ -495,7 +550,8 @@ ufs_diropen(UFS *ufs, const char *path, const char *pattern)
     if (fd < 0) return NULL;
 
     ddesc = (UFSDDESC *)calloc(1, sizeof(UFSDDESC));
-    if (!ddesc) return NULL;
+    if (!ddesc)
+        return diropen_fail(ufs, NULL, NULL, (unsigned)fd);
 
     memcpy(ddesc->eye, "LIBUFSDD", 8);
     ddesc->token = ufs->token;
@@ -505,17 +561,24 @@ ufs_diropen(UFS *ufs, const char *path, const char *pattern)
     cap     = 32;
     n       = 0;
     entries = (UFSDLIST *)malloc(cap * sizeof(UFSDLIST));
-    if (!entries) { free(ddesc); return NULL; }
+    if (!entries)
+        return diropen_fail(ufs, ddesc, NULL, (unsigned)fd);
 
     for (;;) {
+        /* dirread_one separates the two: 0 is end of directory, a
+        ** negative rc is a failed read.  Stopping on both would hand
+        ** back a partial directory that looks complete. */
         rc = dirread_one(ddesc, &entry);
-        if (rc <= 0) break;
+        if (rc == 0) break;
+        if (rc < 0)
+            return diropen_fail(ufs, ddesc, entries, (unsigned)fd);
 
         if (n >= cap) {
             UFSDLIST *tmp;
             cap *= 2;
             tmp = (UFSDLIST *)realloc(entries, cap * sizeof(UFSDLIST));
-            if (!tmp) break;
+            if (!tmp)
+                return diropen_fail(ufs, ddesc, entries, (unsigned)fd);
             entries = tmp;
         }
         entries[n++] = entry;
@@ -677,7 +740,15 @@ ufs_fopen(UFS *ufs, const char *path, const char *mode_str)
 
     ufs->last_rc = UFSD_RC_OK;
     fp = (UFSFILE *)calloc(1, sizeof(UFSFILE));
-    if (!fp) return NULL;
+    if (!fp) {
+        /* FOPEN already took one of the server's global file slots.
+        ** last_rc was set to OK three lines up; leaving it there would
+        ** give the caller a NULL return with a success code. */
+        release_req(UFSREQ_FCLOSE, ufs->token,
+                    (unsigned)*(int *)ufsssob.data, 4U);
+        ufs->last_rc = UFSD_RC_IO;
+        return NULL;
+    }
 
     memcpy(fp->eye, "LIBUFSFP", 8);
     fp->token = ufs->token;


### PR DESCRIPTION
Closes #45.

Every local NULL check was already in place. What was missing is the server-side resource acquired a few lines earlier, and libufs is linked into ftpd, httpd and mvsmf, so these paths have the widest blast radius in the sweep.

## Leaked handles

| Site | Held after | Consequence |
|---|---|---|
| `ufsnew` | `SESS_OPEN` | session slot gone; `UFSD_MAX_SESSIONS` is finite |
| `ufs_diropen` (2 sites) | `DIROPEN` | directory handle gone |
| `ufs_fopen` | `FOPEN` | global file slot gone; `UFSD_MAX_GFILES` is finite |

None of these is reachable again once the response is discarded — the token or fd existed only in the buffer being thrown away, so nothing ever closes them and the slot is burned until the server restarts.

A new `release_req` helper (sibling to `path_req`, same doc-block style) hands the resource back. `diropen_fail` wraps it for `ufs_diropen`, which has three exits to roll back and a partially built descriptor to free. Both are best-effort by design: the caller is already returning an error and has nothing useful to do with a second failure.

## Truncated listing reported as complete

The issue names the `realloc`: it broke out of the loop and the partial result was returned with `nentries` set as though the read had finished, so ftpd LIST/NLST showed a partial directory with no error.

**The same defect sat three lines above it.** `dirread_one` does distinguish end of directory (returns 0) from a failed read (returns negative, on SSI failure, a non-OK rc, or a short response) — but the loop condition was `if (rc <= 0) break;`, collapsing both into the same "we're done" path. A read failure mid-directory produced exactly the truncated-looks-complete result. Both now error out.

## `last_rc`

`ufs_fopen` sets `last_rc = UFSD_RC_OK` *before* the allocation, so the failure path has to overwrite it — otherwise the caller gets a NULL return alongside a success code.

`ufs_diropen` sets it too, which is a small inconsistency worth naming: the function's four pre-existing NULL returns leave `last_rc` untouched. That matters because `ftpd#ufs.c:352` reports via `ufs_last_rc(ufs)`, so those paths already name whatever failed last rather than what just failed. Fixing them is a separate change; I did not want the paths added here to join them.

`UFSD_RC_IO` is the code used, as in #44 — `include/ufsdrc.h` has no NOMEM-ish value and adding one changes an enum shipped to every consumer.

## Testing

**No automated test for the allocation branches** — same reason as #44: the toolchain cannot inject an allocation failure.

The happy paths are covered automatically here, though, which is better than #44: `LIBUFTST` links `client/libufs.c` directly, and `make test-mvs` passed batch + TSO CC 0 against the running server, exercising `ufsnew`, `ufs_fopen` and — the function carrying three of the five sites — `ufs_diropen`, including the rewritten loop. The listing came back with the same three entries as before the change, so end-of-directory still terminates normally rather than erroring out.

No deploy needed: this is the client library. Consumers pick it up by rebuilding against a libufs release, not from the running server.