### PR TITLE
Add the STEPLIB activation job, and say why the banner can lie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ CLAUDE.md
 # Build system
 .env
 *.jcl
+!tests/jcl/*.jcl
 .build-warnings
 .mbt/
 build/

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,6 +54,15 @@ Other targets: `make all` (modules + library), `make modules`, the test targets
 `compile_commands.json` for clangd), and `make clean` / `distclean`.
 `VERBOSE=1 make` echoes the full cc370/as370/ld370/ar370 commands.
 
+**Run `make clean` after a version bump.** The version in the startup banner
+(`UFSD000I` / `UFSD001I`) comes from `-DVERSION`, which `project.toml` puts on
+the compile line from `VERSION`. Changing `VERSION` invalidates no object file,
+so an incremental build keeps whatever string `ufsd.o` was compiled with and the
+server reports the old version — while every other module in the load library is
+current. A deploy can therefore be entirely correct and still be contradicted by
+the banner. Do not use the banner alone to confirm which build is running; a
+string that only exists in the new code is the reliable check.
+
 ### Project Structure
 
 ```

--- a/tests/jcl/UFSDACT.jcl
+++ b/tests/jcl/UFSDACT.jcl
@@ -1,0 +1,81 @@
+//UFSDACT  JOB (ACCT),'ACTIVATE UFSD',CLASS=A,MSGCLASS=H,
+//         NOTIFY=&SYSUID
+//*
+//* Compress the UFSD STEPLIB and copy freshly deployed UFSD load
+//* modules into it.
+//*
+//* WHY THIS EXISTS
+//*   `make deploy` RECEIVEs into the deploy library built from
+//*   MBT_MVS_HLQ in .env -- by default
+//*   <hlq>.UFSD.<vrm>.LINKLIB -- and stops there. The started task
+//*   runs from a different data set (its STEPLIB DD), so a deploy
+//*   on its own changes nothing that is running.
+//*
+//*   There is no hot activation. UFSD is the running program
+//*   itself, and it __loadhi's UFSDSSIR into CSA at startup --
+//*   both only change on a stop/start cycle.
+//*
+//* BEFORE YOU SUBMIT
+//*   Both steps use DISP=OLD, because IEBCOPY COMPRESS cannot run
+//*   against a library UFSD holds SHR through its STEPLIB. The job
+//*   therefore WAITS in the enqueue until UFSD releases it. Submit
+//*   this first, then stop UFSD -- it starts the moment the STC
+//*   ends. Note that a waiting job occupies an initiator.
+//*
+//*     <submit this job>
+//*     P UFSD           (3270 / console)
+//*     <job runs>
+//*     S UFSD
+//*
+//*   Use P, not C. A clean /P UFSD frees all CSA; after /C or an
+//*   abend the recovery handler deliberately retains it, and
+//*   UFSDCLNP has to run before UFSD starts again:
+//*
+//*     S UFSDCLNP
+//*     S UFSD
+//*
+//*   Every UFS client loses its filesystem while UFSD is down --
+//*   ftpd and httpd answer UFS requests with "service not
+//*   available" until it is back.
+//*
+//* CHECK THE NAMES
+//*   Both data sets below are installation-specific. The load
+//*   library is whatever you restored the XMIT to at install time
+//*   -- docs/installation.md uses UFSD.V1R0M0.LINKLIB as its
+//*   example, this stand runs UFSD.LINKLIB. Read the PROC rather
+//*   than assuming either:
+//*
+//*     SYS2.PROCLIB(UFSD)  ->  //STEPLIB DD DSN=...
+//*
+//*   The deploy library is the one `make deploy` prints as its
+//*   target.
+//*
+//* AFTERWARDS
+//*   Confirm the new module is really the one running -- a deploy
+//*   to the wrong library fails silently.
+//*
+//*   Do NOT trust the version in UFSD001I for that. It comes from
+//*   -DVERSION, and bumping VERSION invalidates no object file, so
+//*   an incremental build keeps whatever string ufsd.o was built
+//*   with and the banner names the old version. Build clean after
+//*   a bump, or look for a string only the new build has.
+//*
+//*   IEBCOPY prints IEB144I with the tracks left, which is the
+//*   early warning for the next SE37.
+//*
+//COMPRESS EXEC PGM=IEBCOPY
+//SYSPRINT DD SYSOUT=*
+//LIB      DD DSN=UFSD.LINKLIB,DISP=OLD
+//SYSIN    DD *
+  COPY INDD=LIB,OUTDD=LIB
+/*
+//ACTIVATE EXEC PGM=IEBCOPY
+//SYSPRINT DD SYSOUT=*
+//IN       DD DSN=IBMUSER.UFSD.V1R1M0D.LINKLIB,DISP=SHR
+//OUT      DD DSN=UFSD.LINKLIB,DISP=OLD
+//SYSIN    DD *
+  COPY INDD=((IN,R)),OUTDD=OUT
+  SELECT MEMBER=UFSD
+  SELECT MEMBER=UFSDSSIR
+  SELECT MEMBER=UFSDCLNP
+/*


### PR DESCRIPTION
Fallout from deploying #44 to mvsdev. No code changes.

## `tests/jcl/UFSDACT.jcl`

`make deploy` RECEIVEs into `<hlq>.UFSD.<vrm>.LINKLIB` and stops. The started task runs from its STEPLIB — a different data set — so a deploy on its own changes nothing that is running. This is the same gap httpd closes with `tests/jcl/httpdact.jcl`, and the job is modelled on it: compress the STEPLIB, copy `UFSD` / `UFSDSSIR` / `UFSDCLNP` in, with the stop/start sequence in the header.

The UFSD-specific parts of that header are the ones worth reviewing: use `P`, not `C`, because a clean stop frees the CSA while a cancel deliberately retains it and needs UFSDCLNP first; and every UFS client loses its filesystem for the duration.

`.gitignore` has a blanket `*.jcl`, so this needs a `!tests/jcl/*.jcl` exception to be trackable at all.

## The version caveat

Deploying #44 produced a load library that was correct and a startup banner that said `1.0.0-dev` from a `1.1.0-dev` tree. Cause: `-DVERSION` is a compile-line define, and bumping `VERSION` invalidates no object file — `ufsd.o` had not been recompiled since July, so it kept the old string while every other module was current.

That matters beyond cosmetics: the banner is the obvious way to answer "is the new build actually running", and it answers wrong in exactly the case you would use it. `docs/development.md` now says so in the build section, and the job header repeats it where someone would reach for the check. The reliable check is a string that only exists in the new code.

Fixing the underlying dependency gap is an mbt change, not a ufsd one.

## Correction to #46

The findings section of #46 lists the STEPLIB name in `docs/installation.md` as wrong. **It is not.** `UFSD.V1R0M0.LINKLIB` there is an example DSN — line 117 says "replace with the DSN you actually restored to", and the code blocks are annotated `<- your load library`. The name simply differs on this stand because the XMIT was restored elsewhere. I have corrected that claim on #46; the job header now describes it as an example rather than an error.

(`docs/installation.md` is untracked in the working tree, so it is not part of this branch.)