### PR TITLE
Reclaim an orphaned predecessor at startup; abend WTOs tell the truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Client Address Space          UFSD STC Address Space
 ## Known Limitations
 
 - **No per-file permission system.** Access control is mount-level only (RO/RW mode + OWNER restriction). There are no per-file or per-inode permission checks. Full RACF/RAKF integration is planned for a future release.
-- After `/C UFSD`, the ESTAE handler may not fully deregister the SSI — run UFSDCLNP before restarting
+- After `/C UFSD` the ESTAE deliberately retains the SSI registration and CSA; the next `/S UFSD` reclaims them automatically (UFSDCLNP remains the standalone fallback)
 - No symbolic links, hard links, or file locking
 - Maximum file size: 4.06 MB (single indirect blocks)
 - On-disk format is not finalized — images may not be portable across future versions

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -26,53 +26,50 @@ UFSD099I UFSD SHUTDOWN COMPLETE
 (One `UFSD131I` per RW-mounted filesystem; RO mounts are not written back. If a
 client is still in flight when the stop is issued, a short drain delay precedes
 `UFSD095I`; if the drain does not reach zero within its ceiling the daemon
-issues `UFSD098W` and retains the CSA instead — run `/S UFSDCLNP` in that case.)
+issues `UFSD098W` and retains the CSA instead — the next `/S UFSD` reclaims it
+automatically.)
 
 ## Recovery after Abend
 
-If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler runs in emergency mode (`UFSD_SHUT_ABEND`): it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` — stopping new SSI dispatches and letting parked clients bail — then percolates for the MVS dump. It deliberately frees **nothing**: under RTM there is no reliable way to tell whether another address space is still executing inside the router module or the CSA pools, and freeing them then is exactly the S0C4 being recovered from. SSCT, SSI router, and CSA pools are therefore left allocated and reclaimed by UFSDCLNP on the next start — this is by design, not a defect (see [CSA Retained after /C or Abend](#csa-retained-after-c-cancel-or-abend-by-design)).
-
-**Symptoms of stale resources:**
-
-- `/S UFSD` fails with `IEF612I PROCEDURE NOT FOUND` (JES2 proc name still locked after abend)
-- A new UFSD instance starts but fails to register the SSCT ("subsystem already registered")
-- Clients get S0C4 when calling `ufsnew()` (stale CSA pointers)
+If UFSD abends (S0C4, S222 from `/C`, etc.), the ESTAE handler runs in emergency mode (`UFSD_SHUT_ABEND`): it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` — stopping new SSI dispatches and letting parked clients bail — then percolates for the MVS dump. It deliberately frees **nothing**: under RTM there is no reliable way to tell whether another address space is still executing inside the router module or the CSA pools, and freeing them then is exactly the S0C4 being recovered from. SSCT, SSI router, and CSA pools are therefore left allocated; the final console message states this (`UFSD097W … CSA RETAINED, RECLAIMED AT NEXT START`). This is by design, not a defect (see [CSA Retained after /C or Abend](#csa-retained-after-c-cancel-or-abend-by-design)).
 
 ### Recovery Procedure
 
-1. Run the UFSDCLNP emergency cleanup:
+Restart UFSD:
 
-   ```
-   /S UFSDCLNP
-   ```
+```
+/S UFSD
+```
 
-   Console output:
+Startup detects the orphaned predecessor itself (`ufsd_reclaim()`, shared with UFSDCLNP) and reclaims it before registering — quiesce, drain, deregister, free — so no separate cleanup step is needed. Console output of a start over an orphan:
 
-   ```
-   UFSD140I UFSDCLNP STARTING
-   UFSD144I UFSDCLNP: SSVT FUNCTION POINTER CLEARED
-   UFSD145I UFSDCLNP: SSCT DEREGISTERED
-   UFSD146I UFSDCLNP: SSI ROUTER MODULE FREED
-   UFSD147I UFSDCLNP: CSA POOLS FREED
-   UFSD148I UFSDCLNP: ANCHOR FREED
-   UFSD149I UFSDCLNP COMPLETE
-   ```
+```
+UFSD000I UFSD 1.1.0 STARTING
+UFSD144I RECLAIM: SSVT FUNCTION POINTER CLEARED
+UFSD145I RECLAIM: SSCT DEREGISTERED
+UFSD146I RECLAIM: SSI ROUTER MODULE FREED
+UFSD147I RECLAIM: CSA POOLS FREED
+UFSD148I RECLAIM: ANCHOR FREED
+UFSD004I ORPHANED PREDECESSOR RECLAIMED -- CSA RECOVERED
+UFSD030I CSA ALLOCATED: ANCHOR=...
+```
 
-   (If clients were parked in the router when UFSD died, a short drain delay
-   precedes `UFSD145I` while they bail; a count still standing after the
-   ceiling yields `UFSD152W … ASSUMING LEAKED, FREEING` and cleanup proceeds.)
+(If clients were parked in the router when UFSD died, a short drain delay
+precedes `UFSD145I` while they bail; a count still standing after the
+ceiling yields `UFSD152W … ASSUMING LEAKED, FREEING` and reclaim proceeds.)
 
-2. Restart UFSD:
+Startup refuses to reclaim a predecessor whose anchor is still flagged ACTIVE (`UFSD002E UFSD ALREADY REGISTERED AND ACTIVE`) — every shutdown path clears the flag before the STC ends, so a set flag means a UFSD instance is (or appears to be) still running. If the instance is genuinely gone (e.g. after a FORCE, where the ESTAE never ran), use the standalone fallback, which reclaims unconditionally:
 
-   ```
-   /S UFSD
-   ```
+```
+/S UFSDCLNP
+/S UFSD
+```
 
-If JES2 still refuses the proc name, wait for the old job to be purged (check `$DA` or `$DQ` for stuck entries), or use `$PJ` to purge it manually.
+If JES2 refuses the proc name after an abend, wait for the old job to be purged (check `$DA` or `$DQ` for stuck entries), or use `$PJ` to purge it manually.
 
 ### UFSDCLNP Details
 
-UFSDCLNP is a standalone program that locates the UFSD anchor in CSA via the SSCT chain, then tears down all resources:
+UFSDCLNP is a standalone program wrapping the same shared reclaim routine (`ufsd_reclaim()`, `src/ufsd#rcl.c`) that UFSD startup runs. It locates the UFSD anchor in CSA via the SSCT chain, then tears down all resources:
 
 1. Nulls the SSVT function pointer (no new SSI dispatches) and clears `UFSD_ANCHOR_ACTIVE` (a client parked in the router bails on its next timeout)
 2. **Drains `anchor->inflight` to zero** — keeping the eye catcher and the router module present — so a parked client bails `RC_CORRUPT` and leaves the module *before* it is freed (best-effort, ~12 s ceiling; see below)
@@ -97,13 +94,13 @@ Copy the UFSDCLNP STC procedure from `samplib/ufsdclnp` to `SYS2.PROCLIB(UFSDCLN
 
 After `/C UFSD` or any abend, the ESTAE handler runs in `UFSD_SHUT_ABEND` mode: it nulls the SSVT function entry and clears `UFSD_ANCHOR_ACTIVE` (so `iefssreq` stops routing new clients into UFSDSSIR and any parked client bails on its next router timeout), then percolates. It **frees nothing** — under RTM a foreign PSW may still be executing inside the router module or touching the CSA pools, and freeing them then is the very S0C4 this behaviour prevents.
 
-So `/S UFSDCLNP` is the **designed** recovery step after `/C` or an abend, not a workaround. UFSDCLNP nulls the SSVT entry (idempotent), clears `UFSD_ANCHOR_ACTIVE`, then **drains `anchor->inflight` to zero before it frees anything** — keeping the eye catcher and the router module present throughout. A client still parked in the router revalidates the (still-valid) eye catcher on its next timeout, sees the cleared flag, and bails `RC_CORRUPT`, decrementing the counter as it leaves. Only once the count reaches zero does UFSDCLNP deregister the SSCT and free the router module, pools, and anchor (invalidating the eye catcher just before the anchor FREEMAIN). This closes the window — present before #39 — where freeing the router out from under a parked client faulted that client's address space (`S0C4`; contained by a client-side ESTAE such as HTTPD's, fatal to a bare libufs batch client).
+The **designed** recovery after `/C` or an abend is simply the next `/S UFSD`: startup runs the shared reclaim routine (`ufsd_reclaim()`, `src/ufsd#rcl.c`) before registering. It nulls the SSVT entry (idempotent), clears `UFSD_ANCHOR_ACTIVE`, then **drains `anchor->inflight` to zero before it frees anything** — keeping the eye catcher and the router module present throughout. A client still parked in the router revalidates the (still-valid) eye catcher on its next timeout, sees the cleared flag, and bails `RC_CORRUPT`, decrementing the counter as it leaves. Only once the count reaches zero does the reclaim deregister the SSCT and free the router module, pools, and anchor (invalidating the eye catcher just before the anchor FREEMAIN). This closes the window — present before #39 — where freeing the router out from under a parked client faulted that client's address space (`S0C4`; contained by a client-side ESTAE such as HTTPD's, fatal to a bare libufs batch client). The same routine backs the standalone `/S UFSDCLNP`.
 
-The drain is **best-effort**, ceiling ~12 s (two `UFSD_WAIT_INTERVAL`s, so a live parked client gets two wake-and-bail chances). A count still standing after that is almost certainly leaked — a client that faulted or was cancelled while in-flight never runs its decrement — so UFSDCLNP warns (`UFSD152W`) and frees anyway rather than strand the CSA. So a genuinely stuck worker does not hang the cleanup indefinitely; worst case UFSDCLNP waits ~12 s, then reclaims.
+The drain is **best-effort**, ceiling ~12 s (two `UFSD_WAIT_INTERVAL`s, so a live parked client gets two wake-and-bail chances). A count still standing after that is almost certainly leaked — a client that faulted or was cancelled while in-flight never runs its decrement — so the reclaim warns (`UFSD152W`) and frees anyway rather than strand the CSA. So a genuinely stuck worker does not hang the cleanup indefinitely; worst case the reclaim waits ~12 s, then frees.
 
-A clean `/P UFSD` (or `/F UFSD,SHUTDOWN`) runs in `UFSD_SHUT_NORMAL` mode instead: it nulls the SSVT entry, clears `UFSD_ANCHOR_ACTIVE`, then **drains** `anchor->inflight` to zero and frees the CSA itself — no UFSDCLNP needed after a normal stop. If the drain does not reach zero within its ceiling (~10 s), UFSD issues `UFSD098W` and retains the CSA rather than freeing storage a client may still be executing; run `/S UFSDCLNP` in that case.
+A clean `/P UFSD` (or `/F UFSD,SHUTDOWN`) runs in `UFSD_SHUT_NORMAL` mode instead: it nulls the SSVT entry, clears `UFSD_ANCHOR_ACTIVE`, then **drains** `anchor->inflight` to zero and frees the CSA itself — nothing left behind after a normal stop. If the drain does not reach zero within its ceiling (~10 s), UFSD issues `UFSD098W` and retains the CSA rather than freeing storage a client may still be executing; the next `/S UFSD` reclaims it.
 
-**TSK-71** (ESTAE handler "incomplete" after `/C`) is closed by this: the retained CSA is intended, and UFSDCLNP is the supported recovery path.
+**TSK-71**: the retained CSA after `/C` or an abend is intended; since #49 the next `/S UFSD` reclaims it automatically, and the abend path's final WTO states the CSA state (`UFSD097W`) instead of a misleading `SHUTDOWN COMPLETE`.
 
 ### No Per-File Permission System
 
@@ -131,6 +128,9 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 |---------|----------|-------------|
 | UFSD000I | I | UFSD starting (version) |
 | UFSD001I | I | Ready — version + CSA/session/file summary |
+| UFSD002E | E | Predecessor SSCT found with ACTIVE anchor — refusing to start (run UFSDCLNP if orphaned) |
+| UFSD003E | E | Predecessor reclaim failed (supervisor state) — startup fails |
+| UFSD004I | I | Orphaned predecessor reclaimed at startup — CSA recovered |
 | UFSD030I | I | CSA anchor allocated |
 | UFSD031I–033I | I | Pool sizes (request pool / buffer pool / trace buffer) |
 | UFSD034I | I | SSCT registered |
@@ -150,11 +150,11 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD046I | I | Session table freed |
 | UFSD048I | I | Global file table freed |
 | UFSD096I | I | CSA freed |
-| UFSD097E | E | Cannot enter supervisor state at shutdown — CSA retained, run UFSDCLNP |
-| UFSD097W | W | Abend shutdown — CSA retained, run UFSDCLNP before restart |
+| UFSD097E | E | Cannot enter supervisor state at shutdown — CSA retained, run UFSDCLNP (ACTIVE flag stays set, so startup will refuse the orphan) |
+| UFSD097W | W | Abend shutdown — CSA retained, reclaimed at next start (final message of the abend path) |
 | UFSD098E | E | Abend intercepted — emergency shutdown |
-| UFSD098W | W | Client(s) still in flight at shutdown — CSA retained, run UFSDCLNP |
-| UFSD099I | I | Shutdown complete |
+| UFSD098W | W | Client(s) still in flight at shutdown — CSA retained, reclaimed at next start |
+| UFSD099I | I | Shutdown complete (normal shutdown only; not issued on the abend path) |
 
 ### Configuration and Mounts (060–079, 120–129)
 
@@ -175,22 +175,26 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD110I | I | Sessions list (from /F UFSD,SESSIONS) |
 | UFSD111I | I | Session pruned (stale ASID) |
 
-### UFSDCLNP (140–149, 152–154)
+### Reclaim and UFSDCLNP (140–149, 152–154)
+
+Messages 143–148 and 152–154 come from the shared reclaim routine
+(`RECLAIM:` prefix) and appear both during UFSD startup (over an orphaned
+predecessor) and under standalone UFSDCLNP.
 
 | Message | Severity | Description |
 |---------|----------|-------------|
 | UFSD140I | I | UFSDCLNP starting |
 | UFSD141E | E | APF setup failed (STEPLIB not APF-authorized?) |
 | UFSD142I | I | Subsystem UFSD not registered — nothing to do (RC 0) |
-| UFSD143E | E | Cannot enter supervisor state |
-| UFSD144I | I | SSVT function pointer cleared |
-| UFSD145I | I | SSCT deregistered |
-| UFSD146I | I | SSI router module freed |
-| UFSD147I | I | CSA pools freed |
-| UFSD148I | I | Anchor freed |
+| UFSD143E | E | Reclaim: cannot enter supervisor state |
+| UFSD144I | I | Reclaim: SSVT function pointer cleared |
+| UFSD145I | I | Reclaim: SSCT deregistered |
+| UFSD146I | I | Reclaim: SSI router module freed |
+| UFSD147I | I | Reclaim: CSA pools freed |
+| UFSD148I | I | Reclaim: anchor freed |
 | UFSD149I | I | UFSDCLNP complete |
-| UFSD152W | W | Client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
-| UFSD153W | W | Anchor eye-catcher mismatch — anchor not freed |
-| UFSD154I | I | No anchor (ssctsuse=NULL) — nothing to free |
+| UFSD152W | W | Reclaim: client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
+| UFSD153W | W | Reclaim: anchor eye-catcher mismatch — anchor not freed |
+| UFSD154I | I | Reclaim: no anchor (ssctsuse=NULL) — nothing to free |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -41,7 +41,11 @@ Restart UFSD:
 /S UFSD
 ```
 
-Startup detects the orphaned predecessor itself (`ufsd_reclaim()`, shared with UFSDCLNP) and reclaims it before registering — quiesce, drain, deregister, free — so no separate cleanup step is needed. Console output of a start over an orphan:
+Startup detects the orphaned predecessor itself (`ufsd_reclaim()`, shared with UFSDCLNP) and reclaims it before registering — quiesce, drain, deregister, free — so no separate cleanup step is needed.
+
+**Prerequisite: `SYS1.PROCLIB(UFSD)` must be installed** (`samplib/ufsdmstr`). While a UFSD SSCT is registered, MVS converts `S UFSD` under the **master subsystem** — the subsystem name matches — and the master's `IEFPDSI` knows only `SYS1.PROCLIB`. Without the companion member the start fails with `IEF612I PROCEDURE NOT FOUND` before any UFSD code runs (this is the real mechanism behind the long-observed "proc not found after abend" symptom). After a clean stop no SSCT exists and the start goes through JES2 and `SYS2.PROCLIB(UFSD)` as usual.
+
+Console output of a start over an orphan (MVS-verified 2026-08-10):
 
 ```
 UFSD000I UFSD 1.1.0 STARTING
@@ -65,7 +69,7 @@ Startup refuses to reclaim a predecessor whose anchor is still flagged ACTIVE (`
 /S UFSD
 ```
 
-If JES2 refuses the proc name after an abend, wait for the old job to be purged (check `$DA` or `$DQ` for stuck entries), or use `$PJ` to purge it manually.
+(`IEF612I` on `/S UFSD` after an abend is **not** a JES2 stuck-job problem — it is the master-subsystem conversion described above, and installing `SYS1.PROCLIB(UFSD)` resolves it.)
 
 ### UFSDCLNP Details
 
@@ -86,7 +90,7 @@ UFSDCLNP is safe to run when UFSD is not registered — it reports "nothing to d
 
 ### Installation
 
-Copy the UFSDCLNP STC procedure from `samplib/ufsdclnp` to `SYS2.PROCLIB(UFSDCLNP)`.
+Copy the UFSDCLNP STC procedure from `samplib/ufsdclnp` to `SYS2.PROCLIB(UFSDCLNP)`, and the MSTR companion procedure from `samplib/ufsdmstr` to `SYS1.PROCLIB(UFSD)` (required for the post-abend `/S UFSD` — see [Recovery Procedure](#recovery-procedure)).
 
 ## Known Issues
 

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -531,11 +531,29 @@ int  ufsd_process_cib(UFSD_STC *ufsd, CIB *cib);
 **                   in-flight clients is unknown, and freeing CSA
 **                   that a foreign PSW may be executing is exactly
 **                   the S0C4 this fix is meant to prevent.
-**                   UFSDCLNP reclaims on the next start. */
+**                   The next start reclaims the CSA (ufsd_reclaim,
+**                   #49); UFSDCLNP is the standalone fallback. */
 #define UFSD_SHUT_NORMAL  0
 #define UFSD_SHUT_ABEND   1
 
 void ufsd_shutdown(UFSD_STC *ufsd, int mode);
+
+/* ufsd#rcl.c (#49) -- orphaned predecessor reclaim, shared by UFSD
+** startup and the standalone UFSDCLNP utility.
+**
+** Finds a registered "UFSD" SSCT and, unless its anchor is still
+** flagged ACTIVE (every shutdown path clears the flag before the STC
+** ends, so a set flag means a live server), quiesces and frees it:
+** null the SSVT entry, clear ANCHOR_ACTIVE, drain inflight with the
+** router module still present, then deregister and free all CSA.
+** `force` skips the ACTIVE check (UFSDCLNP emergency semantics).
+** Caller must be APF authorized and not under RTM. */
+#define UFSD_RECLAIM_NONE     0     /* no UFSD SSCT registered           */
+#define UFSD_RECLAIM_DONE     1     /* orphaned predecessor reclaimed    */
+#define UFSD_RECLAIM_ACTIVE   2     /* predecessor looks live; untouched */
+#define UFSD_RECLAIM_FAIL   (-1)    /* cannot enter supervisor state     */
+
+int ufsd_reclaim(int force)                                          asm("UFSD@RCL");
 
 /* ufsd#csa.c (AP-1b) */
 UFSD_ANCHOR *ufsd_anchor_alloc(void)                                 asm("UFSD@ANA");

--- a/project.toml
+++ b/project.toml
@@ -26,10 +26,11 @@ ac = 1
 sources = ["src/ufsd#ssi.c", "src/ufsd#buf.c"]
 
 # UFSDCLNP — cleanup utility (all defaults: entry=@@CRT0, startup=crt0)
+# Wraps the shared reclaim routine (ufsd#rcl.c, also part of UFSD).
 [[module]]
 name = "UFSDCLNP"
 ac = 1
-sources = ["src/ufsdclnp.c"]
+sources = ["src/ufsdclnp.c", "src/ufsd#rcl.c"]
 
 # ── Tests ────────────────────────────────────────────────
 [[test]]

--- a/samplib/ufsd
+++ b/samplib/ufsd
@@ -15,10 +15,13 @@
 //*              /F UFSD,SHUTDOWN
 //* Stopping:    /P UFSD
 //*
-//* Recovery:    If UFSD abends (/C or S0Cx), the SSCT and CSA may
-//*              remain allocated.  Run UFSDCLNP before restarting:
-//*                /S UFSDCLNP     (if installed as STC proc)
-//*              or submit the UFSDCLNP batch JCL from SAMPLIB.
+//* Recovery:    After an abend (/C or S0Cx) the SSCT and CSA remain
+//*              allocated by design; the next /S UFSD reclaims them.
+//*              NOTE: that start converts under the MASTER subsystem
+//*              (the orphaned SSCT redirects it), so the UFSDMSTR
+//*              companion MUST be installed as SYS1.PROCLIB(UFSD) --
+//*              without it the start fails with IEF612I.  UFSDCLNP
+//*              remains the standalone fallback (see SAMPLIB).
 //*
 //UFSD     EXEC PGM=UFSD,REGION=4M,TIME=1440
 //STEPLIB  DD  DISP=SHR,DSN=UFSD.LINKLIB

--- a/samplib/ufsdmstr
+++ b/samplib/ufsdmstr
@@ -1,0 +1,29 @@
+//UFSD     PROC M=UFSDPRM0,
+//            D='SYS2.PARMLIB'
+//*
+//* UFSD - MSTR-Subsystem Companion of SYS2.PROCLIB(UFSD)  (issue #49)
+//*
+//* Installation:
+//*   Copy to SYS1.PROCLIB(UFSD)  -- the member name must stay UFSD.
+//*
+//* Why this exists: while a UFSD subsystem (SSCT) is registered --
+//* i.e. after an abend or /C left an orphan behind -- MVS converts
+//* 'S UFSD' under the MASTER subsystem, whose IEFPDSI concatenation
+//* knows only SYS1.PROCLIB.  Without this member that start dies
+//* with IEF612I PROCEDURE NOT FOUND and the startup auto-reclaim
+//* never runs.  After a clean stop no SSCT exists, the start goes
+//* through JES2, and SYS2.PROCLIB(UFSD) is used as usual.
+//*
+//* Keep in sync with SYS2.PROCLIB(UFSD).  Differences are deliberate:
+//* SYSOUT is not available to a task started under the master
+//* subsystem, so SYSUDUMP is DUMMY and SYSPRINT/SYSTERM are present
+//* as DUMMY to keep the C runtime from allocating a SYSOUT for
+//* stdout/stderr (S013-C0 otherwise).  All operational output goes
+//* to the console via WTO anyway.
+//*
+//UFSD     EXEC PGM=UFSD,REGION=4M,TIME=1440
+//STEPLIB  DD  DISP=SHR,DSN=UFSD.LINKLIB
+//UFSDPRM  DD  DISP=SHR,DSN=&D(&M),FREE=CLOSE
+//SYSPRINT DD  DUMMY
+//SYSTERM  DD  DUMMY
+//SYSUDUMP DD  DUMMY

--- a/src/ufsd#rcl.c
+++ b/src/ufsd#rcl.c
@@ -1,0 +1,198 @@
+/* UFSD#RCL.C - Orphaned Predecessor Reclaim (issue #49)
+**
+** Shared teardown for a UFSD instance that terminated without freeing
+** its CSA footprint.  After an abend the ESTAE path deliberately frees
+** nothing (see ufsd.c): the SSCT stays chained, the SSI router module
+** and the pools stay in CSA.  Both callers run the same MVS-verified
+** sequence (originally in ufsdclnp.c, moved here):
+**
+**   UFSD startup   main() reclaims BEFORE registering, so after /C a
+**                  plain /S UFSD suffices: no second SSCT chained, no
+**                  CSA leak.  force=0 -- a predecessor whose anchor is
+**                  still flagged ACTIVE is treated as a running server
+**                  and left untouched.
+**   UFSDCLNP       standalone emergency utility.  force=1 -- reclaims
+**                  unconditionally (its historical semantics).
+**
+** Quiescing (#39): null the SSVT entry and clear UFSD_ANCHOR_ACTIVE,
+** then DRAIN anchor->inflight to zero -- keeping the eye catcher and
+** the router module present -- so a client still parked in UFSDSSIR
+** bails RC_CORRUPT on its next timeout and leaves the module before we
+** free it.  Freeing the router out from under a parked client is an
+** S0C4 in that client's address space (see issue #39); the drain
+** closes that window.  It is best-effort: a count still standing after
+** the ceiling is almost certainly leaked (a client that faulted or
+** whose AS was cancelled while in-flight never runs its decrement), so
+** we warn and free anyway -- the alternative is stranding the CSA
+** until an IPL.
+*/
+
+#include "ufsd.h"
+#include <string.h>
+#include <clibos.h>
+#include <clibwto.h>
+
+/* Drain tuning -- see ufsd.c ufsd_drain().  The ceiling exceeds
+** 2 * UFSD_WAIT_INTERVAL (2 * 5.00 s) so a client genuinely parked in the
+** router gets two wake-and-bail chances before we conclude the count is
+** leaked and free anyway. */
+#define UFSD_RCL_DRAIN_POLL    10U   /* 0.10 s per poll                    */
+#define UFSD_RCL_DRAIN_MAX    120U   /* 120 * 0.10 s = 12.00 s ceiling     */
+#define UFSD_RCL_DRAIN_SETTLE  20U   /* 0.20 s after inflight reaches zero */
+
+/* Block for `hsec` hundredths on a private stack ECB nobody posts -- the
+** interval timer wakes us.  Same primitive as ufsd_pause() in ufsd.c. */
+static void
+ufsd_rcl_pause(unsigned hsec)
+{
+    ECB local = 0;
+    ecb_timed_wait(&local, hsec, 0);
+}
+
+/* Poll anchor->inflight to zero.  Returns 1 if it drained, 0 on ceiling.
+** Runs in problem state: inflight is in CSA without fetch-protection and
+** another address space decrements it (volatile: reload every poll). */
+static int
+ufsd_rcl_drain(UFSD_ANCHOR *anchor)
+{
+    volatile unsigned *inflight = &anchor->inflight;
+    unsigned           n;
+
+    for (n = 0; n < UFSD_RCL_DRAIN_MAX; n++) {
+        if (*inflight == 0) {
+            ufsd_rcl_pause(UFSD_RCL_DRAIN_SETTLE);
+            return (*inflight == 0);      /* re-check: catch a racing exit */
+        }
+        ufsd_rcl_pause(UFSD_RCL_DRAIN_POLL);
+    }
+    return 0;
+}
+
+/* ============================================================
+** ufsd_reclaim
+**
+** Find a registered "UFSD" SSCT and reclaim it: quiesce, drain,
+** deregister, free all CSA.  Caller must be APF authorized and
+** in a normal task environment (timed WAITs; not under RTM).
+**
+** Returns UFSD_RECLAIM_NONE / _DONE / _ACTIVE / _FAIL.
+** ============================================================ */
+int
+ufsd_reclaim(int force)
+{
+    SSCT           *ssct;
+    SSVT           *ssvt;
+    UFSD_ANCHOR    *anchor;
+    unsigned char   savekey;
+    int             anchor_ok;
+
+    ssct = ssct_find("UFSD");
+    if (!ssct)
+        return UFSD_RECLAIM_NONE;
+
+    ssvt      = ssct->ssctssvt;
+    anchor    = (UFSD_ANCHOR *)ssct->ssctsuse;
+    anchor_ok = (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0);
+
+    /* Liveness gate.  Every path out of a UFSD instance -- clean /P,
+    ** drain-timeout retain, and the ESTAE -- clears UFSD_ANCHOR_ACTIVE
+    ** before the STC ends, so a set flag means a running server (or one
+    ** whose ESTAE never got to run, e.g. after FORCE).  Tearing that
+    ** down would yank the CSA from under live clients; without `force`,
+    ** hands off.  An SSCT without a valid anchor cannot be a live
+    ** server -- reclaim it. */
+    if (!force && anchor_ok && (anchor->flags & UFSD_ANCHOR_ACTIVE))
+        return UFSD_RECLAIM_ACTIVE;
+
+    /* --- Step 1: close the door and arm the parked-client bail ---
+    ** Null the SSVT entry so no NEW iefssreq call dispatches into UFSDSSIR,
+    ** and clear UFSD_ANCHOR_ACTIVE so a client already parked in the router
+    ** bails RC_CORRUPT on its next timeout.  Keep the eye catcher and the
+    ** router module present: the router decrements inflight ONLY on the
+    ** "eye still valid" bail path, so clearing the eye now would strand the
+    ** counter and defeat the drain in step 2. */
+    if (__super(PSWKEY0, &savekey)) {
+        wtof("UFSD143E RECLAIM: CANNOT ENTER SUPERVISOR STATE");
+        return UFSD_RECLAIM_FAIL;
+    }
+    if (ssvt) {
+        ssvt_reset(ssvt, UFSD_SSVT_ROUTER);
+        ssvt_funcmap(ssvt, 0, UFSD_SSOBFUNC);
+        wtof("UFSD144I RECLAIM: SSVT FUNCTION POINTER CLEARED");
+    }
+    if (anchor_ok)
+        anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
+    __prob(savekey, NULL);
+
+    /* --- Step 2: drain in-flight clients out of the router (problem
+    ** state) --- parked clients need up to one UFSD_WAIT_INTERVAL to notice
+    ** the cleared flag and bail, decrementing inflight on the way out.
+    ** Best-effort: a count still standing after the ceiling is treated as
+    ** leaked and freed anyway (see file header). */
+    if (anchor_ok && anchor->inflight) {
+        if (!ufsd_rcl_drain(anchor))
+            wtof("UFSD152W RECLAIM: %u CLIENT(S) STILL IN FLIGHT AFTER "
+                 "DRAIN -- ASSUMING LEAKED, FREEING", anchor->inflight);
+    }
+
+    /* --- Step 3: tear down under key-0 -- deregister the SSCT (frees the
+    ** SSVT), unload the router module, release the pools, then the anchor.
+    ** Order matters: the module references the pool blocks, so it goes
+    ** first; the anchor goes last. */
+    if (__super(PSWKEY0, &savekey)) {
+        wtof("UFSD143E RECLAIM: CANNOT ENTER SUPERVISOR STATE");
+        return UFSD_RECLAIM_FAIL;
+    }
+
+    ssct_remove(ssct);
+    ssct_free(ssct);
+    if (ssvt) ssvt_free(ssvt);
+    wtof("UFSD145I RECLAIM: SSCT DEREGISTERED");
+
+    if (anchor_ok) {
+        /* Free UFSDSSIR CSA load module */
+        if (anchor->ssir_lpa) {
+            freemain(anchor->ssir_lpa);
+            anchor->ssir_lpa = NULL;
+            wtof("UFSD146I RECLAIM: SSI ROUTER MODULE FREED");
+        }
+
+        /* Free trace ring buffer */
+        if (anchor->trace_buf) {
+            freemain(anchor->trace_buf);
+            anchor->trace_buf = NULL;
+        }
+
+        /* Free 4K buffer pool (contiguous allocation) */
+        if (anchor->buf_pool_base) {
+            freemain(anchor->buf_pool_base);
+            anchor->buf_pool_base = NULL;
+            anchor->buf_free      = NULL;
+        }
+
+        /* Free request pool (contiguous allocation) */
+        if (anchor->req_pool_base) {
+            freemain(anchor->req_pool_base);
+            anchor->req_pool_base = NULL;
+            anchor->free_head     = NULL;
+        }
+
+        wtof("UFSD147I RECLAIM: CSA POOLS FREED");
+
+        /* Invalidate the eye catcher BEFORE the FREEMAIN so a client still
+        ** in the drain settle window bails on eye-mismatch instead of
+        ** trusting a live-looking anchor.  Anchor goes last. */
+        memset(anchor->eye, 0, sizeof(anchor->eye));
+        freemain(anchor);
+        wtof("UFSD148I RECLAIM: ANCHOR FREED");
+    } else if (anchor) {
+        wtof("UFSD153W RECLAIM: ANCHOR EYE MISMATCH AT %08X",
+             (unsigned)anchor);
+    } else {
+        wtof("UFSD154I RECLAIM: NO ANCHOR (SSCTSUSE=NULL)");
+    }
+
+    __prob(savekey, NULL);
+
+    return UFSD_RECLAIM_DONE;
+}

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -72,8 +72,18 @@
 **   2. Percolate (SDWACWT = 0): MVS produces the SVC dump and
 **      terminates the address space normally.
 **
-** SDWAPARM holds &ufsd (the STC block on main's stack), set via
-** __estae(ESTAE_CREATE, ufsd_recover, &ufsd).
+** SDWAPARM is the address of the two-word {recovery fp, udata}
+** pair that __estae(ESTAE_CREATE, ufsd_recover, &ufsd) stored for
+** the ESTAE PARAM= operand -- NOT the udata word itself.  &ufsd
+** (the STC block on main's stack) is the pair's second word.
+**
+** Reading SDWAPARM as the STC block directly (as this routine did
+** until #49) made the whole quiesce a silent no-op: the "STC
+** block" was really the param pair, its ->anchor fell into the
+** zeroed slots behind it, and ufsd_shutdown() took the !anchor
+** path -- printing SHUTDOWN COMPLETE while SSVT entry, ACTIVE
+** flag, and CSA all survived untouched.  The eye catcher check
+** guards against any future drift in that plumbing.
 **
 ** ufsd_shutdown() deletes the ESTAE as its first action, so
 ** this routine is never called re-entrantly.
@@ -81,17 +91,22 @@
 static void
 ufsd_recover(SDWA *sdwa)
 {
-    UFSD_STC *ufsd;
+    UFSD_STC  *ufsd;
+    void     **param;
 
     if (!sdwa) return;
 
-    ufsd = (UFSD_STC *)sdwa->SDWAPARM;
+    param = (void **)sdwa->SDWAPARM;
+    ufsd  = param ? (UFSD_STC *)param[1] : NULL;
 
     wtof("UFSD098E UFSD ABEND INTERCEPTED -- EMERGENCY SHUTDOWN");
 
-    if (ufsd) {
+    if (ufsd && memcmp(ufsd->eye, "**UFSD**", 8) == 0) {
         ufsd->flags &= ~UFSD_ACTIVE;
         ufsd_shutdown(ufsd, UFSD_SHUT_ABEND);
+    } else {
+        wtof("UFSD096E RECOVERY: STC BLOCK NOT FOUND -- NOTHING QUIESCED, "
+             "CSA RETAINED");
     }
 
     /* Percolate: let MVS produce the abend dump and terminate */

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -33,8 +33,16 @@
 **     still be executing.
 **   - UFSD_SHUT_ABEND (ESTAE): nulls the entry + clears the flag only,
 **     then percolates for the MVS dump.  Under RTM the state of
-**     in-flight clients is unknown, so nothing is freed.  UFSDCLNP
-**     reclaims the CSA on the next start.
+**     in-flight clients is unknown, so nothing is freed.  The next
+**     start reclaims the CSA (see below).
+**
+** Startup auto-reclaim (Issue #49):
+**   main() calls ufsd_reclaim() (ufsd#rcl.c) before registering: an
+**   orphaned predecessor -- SSCT still chained, CSA still allocated
+**   after an abend -- is quiesced, drained, and freed, so after /C a
+**   plain /S UFSD suffices.  A predecessor still flagged ACTIVE is a
+**   running server and startup refuses; UFSDCLNP stays the standalone
+**   (unconditional) fallback.
 */
 
 #ifndef VERSION
@@ -59,7 +67,8 @@
 **      into UFSDSSIR and parked clients bail on their next timeout.
 **      CSA is NOT freed: under RTM a foreign PSW may still be inside
 **      the router or the pools, and freeing it is the very S0C4 we
-**      are recovering from.  UFSDCLNP reclaims the CSA on next start.
+**      are recovering from.  The next start reclaims the CSA
+**      (ufsd_reclaim); UFSDCLNP is the standalone fallback.
 **   2. Percolate (SDWACWT = 0): MVS produces the SVC dump and
 **      terminates the address space normally.
 **
@@ -162,6 +171,9 @@ ufsd_shutdown(UFSD_STC *ufsd, int mode)
         ** Clearing ANCHOR_ACTIVE alone does not stop that; only the SSVT
         ** entry does.  Same order as UFSDCLNP. */
         if (__super(PSWKEY0, &savekey)) {
+            /* ANCHOR_ACTIVE stays set on this path, so the next start's
+            ** ufsd_reclaim() sees a live-looking predecessor and refuses
+            ** -- only UFSDCLNP (force) reclaims this one. */
             wtof("UFSD097E CANNOT ENTER SUPERVISOR STATE -- "
                  "CSA RETAINED, RUN UFSDCLNP BEFORE RESTART");
             ufsd_ufs_term(ufsd);
@@ -185,16 +197,21 @@ ufsd_shutdown(UFSD_STC *ufsd, int mode)
     if (mode == UFSD_SHUT_ABEND) {
         /* Under RTM we cannot drain and must not free: a foreign PSW may
         ** still be executing inside UFSDSSIR or touching the pools.
-        ** Leave everything and percolate; UFSDCLNP reclaims on restart. */
+        ** Leave everything and percolate; the next start reclaims.
+        ** This must be the LAST WTO of the abend path: during S222
+        ** termination only the first and the last message reliably
+        ** reach the console, so a trailing SHUTDOWN COMPLETE would
+        ** survive in place of this one and misstate the CSA state
+        ** (issue #49). */
         wtof("UFSD097W ABEND SHUTDOWN -- CSA RETAINED, "
-             "RUN UFSDCLNP BEFORE RESTART");
-        goto done;
+             "RECLAIMED AT NEXT START");
+        return;
     }
 
     /* Step 4: drain in-flight clients out of the router. */
     if (!ufsd_drain(anchor)) {
         wtof("UFSD098W %u CLIENT(S) STILL IN FLIGHT -- CSA RETAINED, "
-             "RUN UFSDCLNP BEFORE RESTART", anchor->inflight);
+             "RECLAIMED AT NEXT START", anchor->inflight);
         goto done;                        /* free nothing */
     }
 
@@ -266,6 +283,29 @@ main(int argc, char **argv)
     __estae(ESTAE_CREATE, ufsd_recover, &ufsd);
 
     wtof("UFSD000I UFSD %s STARTING", VERSION);
+
+    /* --- Predecessor reclaim (Issue #49) -------------------------- */
+    /* After an abend the ESTAE path frees nothing: SSCT, router module
+    ** and pools survive the address space (see ufsd_shutdown).  Regis-
+    ** tering fresh over that orphan would chain a SECOND SSCT named
+    ** UFSD and leak the old CSA -- so reclaim first, and do it before
+    ** the new CSA is allocated to keep the peak footprint down.
+    ** Startup is the safe point for the full teardown: normal task,
+    ** timed WAITs allowed, no RTM.  A predecessor still flagged ACTIVE
+    ** is a running server (or one whose ESTAE never ran): refuse to
+    ** start over it. */
+    rc = ufsd_reclaim(0);
+    if (rc == UFSD_RECLAIM_ACTIVE) {
+        wtof("UFSD002E UFSD ALREADY REGISTERED AND ACTIVE -- NOT "
+             "STARTING (IF ORPHANED, RUN UFSDCLNP)");
+        return 8;
+    }
+    if (rc == UFSD_RECLAIM_FAIL) {
+        wtof("UFSD003E PREDECESSOR RECLAIM FAILED -- NOT STARTING");
+        return 8;
+    }
+    if (rc == UFSD_RECLAIM_DONE)
+        wtof("UFSD004I ORPHANED PREDECESSOR RECLAIMED -- CSA RECOVERED");
 
     /* --- CSA anchor ---------------------------------------------- */
     anchor = ufsd_anchor_alloc();

--- a/src/ufsdclnp.c
+++ b/src/ufsdclnp.c
@@ -10,76 +10,31 @@
 **
 ** Requires APF authorization (AC=1 in linkedit, APF STEPLIB).
 **
+** Since #49 the reclaim sequence lives in ufsd_reclaim()
+** (src/ufsd#rcl.c) and UFSD startup runs it itself, so after an abend
+** a plain /S UFSD suffices.  UFSDCLNP stays the standalone fallback:
+** emergencies, older load libraries, and the case startup refuses --
+** a predecessor still flagged ACTIVE (e.g. after FORCE, when the
+** ESTAE never ran).  UFSDCLNP reclaims UNCONDITIONALLY (force=1): it
+** does not distinguish a crashed server from a running one, so stop
+** UFSD first (TSK-124 tracks refusing while the STC is alive).
+**
 ** Recovery cycle after UFSD abend:
+**   /S UFSD           (reclaims the orphan itself, then starts)
+** or standalone:
 **   /S UFSDCLNP       (30 seconds, replaces 15-minute IPL)
 **   /S UFSD
 **   /S HTTPD
-**
-** Quiescing (#39): UFSDCLNP mirrors the clean-/P path.  It nulls the
-** SSVT entry and clears UFSD_ANCHOR_ACTIVE, then DRAINS anchor->inflight
-** to zero -- keeping the eye catcher and the router module present -- so
-** a client still parked in UFSDSSIR bails RC_CORRUPT on its next timeout
-** and leaves the module before we free it.  Freeing the router out from
-** under a parked client is an S0C4 in that client's address space (see
-** issue #39); the drain closes that window.  It is best-effort: a count
-** still standing after the ceiling is almost certainly leaked (a client
-** that faulted or whose AS was cancelled while in-flight never runs its
-** decrement), so we warn and free anyway -- UFSDCLNP has no fallback but
-** an IPL, and stranding CSA is exactly what it exists to prevent.
 */
 
 #include "ufsd.h"
-#include <string.h>
 #include <clibos.h>
 #include <clibwto.h>
-#include <clibssct.h>
-#include <clibssvt.h>
-
-/* Drain tuning -- see ufsd.c ufsd_drain().  The ceiling exceeds
-** 2 * UFSD_WAIT_INTERVAL (2 * 5.00 s) so a client genuinely parked in the
-** router gets two wake-and-bail chances before we conclude the count is
-** leaked and free anyway. */
-#define UFSDCLNP_DRAIN_POLL    10U   /* 0.10 s per poll                    */
-#define UFSDCLNP_DRAIN_MAX    120U   /* 120 * 0.10 s = 12.00 s ceiling     */
-#define UFSDCLNP_DRAIN_SETTLE  20U   /* 0.20 s after inflight reaches zero */
-
-/* Block for `hsec` hundredths on a private stack ECB nobody posts -- the
-** interval timer wakes us.  Same primitive as ufsd_pause() in the STC. */
-static void
-ufsdclnp_pause(unsigned hsec)
-{
-    ECB local = 0;
-    ecb_timed_wait(&local, hsec, 0);
-}
-
-/* Poll anchor->inflight to zero.  Returns 1 if it drained, 0 on ceiling.
-** Runs in problem state: inflight is in CSA without fetch-protection and
-** another address space decrements it (volatile: reload every poll). */
-static int
-ufsdclnp_drain(UFSD_ANCHOR *anchor)
-{
-    volatile unsigned *inflight = &anchor->inflight;
-    unsigned           n;
-
-    for (n = 0; n < UFSDCLNP_DRAIN_MAX; n++) {
-        if (*inflight == 0) {
-            ufsdclnp_pause(UFSDCLNP_DRAIN_SETTLE);
-            return (*inflight == 0);      /* re-check: catch a racing exit */
-        }
-        ufsdclnp_pause(UFSDCLNP_DRAIN_POLL);
-    }
-    return 0;
-}
 
 int
 main(int argc, char **argv)
 {
-    SSCT           *ssct;
-    SSVT           *ssvt;
-    UFSD_ANCHOR    *anchor;
-    unsigned char   savekey;
-    int             anchor_ok;
-    int             rc;
+    int rc;
 
     (void)argc;
 
@@ -92,106 +47,13 @@ main(int argc, char **argv)
         return 8;
     }
 
-    /* --- Locate UFSD subsystem --- */
-    ssct = ssct_find("UFSD");
-    if (!ssct) {
+    rc = ufsd_reclaim(1);
+    if (rc == UFSD_RECLAIM_NONE) {
         wtof("UFSD142I UFSDCLNP: SUBSYSTEM UFSD NOT REGISTERED");
         return 0;
     }
-
-    ssvt      = ssct->ssctssvt;
-    anchor    = (UFSD_ANCHOR *)ssct->ssctsuse;
-    anchor_ok = (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0);
-
-    /* --- Step 1: close the door and arm the parked-client bail ---
-    ** Null the SSVT entry so no NEW iefssreq call dispatches into UFSDSSIR,
-    ** and clear UFSD_ANCHOR_ACTIVE so a client already parked in the router
-    ** bails RC_CORRUPT on its next timeout.  Keep the eye catcher and the
-    ** router module present: the router decrements inflight ONLY on the
-    ** "eye still valid" bail path, so clearing the eye now would strand the
-    ** counter and defeat the drain in step 2. */
-    if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD143E UFSDCLNP: CANNOT ENTER SUPERVISOR STATE");
-        return 8;
-    }
-    if (ssvt) {
-        ssvt_reset(ssvt, UFSD_SSVT_ROUTER);
-        ssvt_funcmap(ssvt, 0, UFSD_SSOBFUNC);
-        wtof("UFSD144I UFSDCLNP: SSVT FUNCTION POINTER CLEARED");
-    }
-    if (anchor_ok)
-        anchor->flags &= ~UFSD_ANCHOR_ACTIVE;
-    __prob(savekey, NULL);
-
-    /* --- Step 2: drain in-flight clients out of the router (problem
-    ** state) --- parked clients need up to one UFSD_WAIT_INTERVAL to notice
-    ** the cleared flag and bail, decrementing inflight on the way out.
-    ** Best-effort: a count still standing after the ceiling is treated as
-    ** leaked and freed anyway (see file header). */
-    if (anchor_ok && anchor->inflight) {
-        if (!ufsdclnp_drain(anchor))
-            wtof("UFSD152W UFSDCLNP: %u CLIENT(S) STILL IN FLIGHT AFTER "
-                 "DRAIN -- ASSUMING LEAKED, FREEING", anchor->inflight);
-    }
-
-    /* --- Step 3: tear down under key-0 -- deregister the SSCT (frees the
-    ** SSVT), unload the router module, release the pools, then the anchor.
-    ** Order matters: the module references the pool blocks, so it goes
-    ** first; the anchor goes last. */
-    if (__super(PSWKEY0, &savekey)) {
-        wtof("UFSD143E UFSDCLNP: CANNOT ENTER SUPERVISOR STATE");
-        return 8;
-    }
-
-    ssct_remove(ssct);
-    ssct_free(ssct);
-    if (ssvt) ssvt_free(ssvt);
-    wtof("UFSD145I UFSDCLNP: SSCT DEREGISTERED");
-
-    if (anchor_ok) {
-        /* Free UFSDSSIR CSA load module */
-        if (anchor->ssir_lpa) {
-            freemain(anchor->ssir_lpa);
-            anchor->ssir_lpa = NULL;
-            wtof("UFSD146I UFSDCLNP: SSI ROUTER MODULE FREED");
-        }
-
-        /* Free trace ring buffer */
-        if (anchor->trace_buf) {
-            freemain(anchor->trace_buf);
-            anchor->trace_buf = NULL;
-        }
-
-        /* Free 4K buffer pool (contiguous allocation) */
-        if (anchor->buf_pool_base) {
-            freemain(anchor->buf_pool_base);
-            anchor->buf_pool_base = NULL;
-            anchor->buf_free      = NULL;
-        }
-
-        /* Free request pool (contiguous allocation) */
-        if (anchor->req_pool_base) {
-            freemain(anchor->req_pool_base);
-            anchor->req_pool_base = NULL;
-            anchor->free_head     = NULL;
-        }
-
-        wtof("UFSD147I UFSDCLNP: CSA POOLS FREED");
-
-        /* Invalidate the eye catcher BEFORE the FREEMAIN so a client still
-        ** in the drain settle window bails on eye-mismatch instead of
-        ** trusting a live-looking anchor.  Anchor goes last. */
-        memset(anchor->eye, 0, sizeof(anchor->eye));
-        freemain(anchor);
-        wtof("UFSD148I UFSDCLNP: ANCHOR FREED");
-    } else if (anchor) {
-        wtof("UFSD153W UFSDCLNP: ANCHOR EYE MISMATCH AT %08X",
-             (unsigned)anchor);
-    } else {
-        wtof("UFSD154I UFSDCLNP: NO ANCHOR (SSCTSUSE=NULL)");
-    }
-
-    __prob(savekey, NULL);
+    if (rc != UFSD_RECLAIM_DONE)
+        return 8;                         /* UFSD143E already issued */
 
     wtof("UFSD149I UFSDCLNP COMPLETE");
     return 0;


### PR DESCRIPTION
Fixes #49 (TSK-71)

## What

**1. Startup auto-reclaim — after `/C` a plain `/S UFSD` suffices.**
The MVS-verified UFSDCLNP sequence (null SSVT entry → clear `ANCHOR_ACTIVE` → drain `inflight` with the router module still present → deregister and free) moves into a shared routine `ufsd_reclaim()` in the new **UFSD#RCL** module. `main()` calls it right after `UFSD000I`, before any CSA is allocated. UFSDCLNP becomes a thin wrapper around the same routine and keeps working standalone.

**2. Liveness gate (`force` parameter).**
Every path out of a UFSD instance clears `UFSD_ANCHOR_ACTIVE` before the STC ends. Startup (`force=0`) refuses to reclaim a predecessor whose flag is still set (`UFSD002E`) instead of yanking CSA from under a running server; UFSDCLNP (`force=1`) keeps its unconditional emergency semantics (TSK-124 stays open for that).

**3. Abend-path WTOs.**
`UFSD_SHUT_ABEND` no longer falls through to `UFSD099I SHUTDOWN COMPLETE`; `UFSD097W … CSA RETAINED, RECLAIMED AT NEXT START` is the final message of the abend path.

## Two defects found and fixed during MVS verification

**4. The ESTAE quiesce was a silent no-op since it was introduced (2nd commit).**
`ufsd_recover()` read `sdwa->SDWAPARM` as the STC block, but SDWAPARM is the address of the `{recovery fp, udata}` pair `__estae()` stores for ESTAE `PARAM=` — the STC block is that pair's *second word*. Read directly, `->anchor` fell into the zeroed param slots, so `ufsd_shutdown()` took the `!anchor` path: it printed SHUTDOWN COMPLETE while SSVT entry, ACTIVE flag and CSA survived untouched. The July finding "UFSD097W is emitted but lost during S222" was a misreading — the message was never emitted, and `/C` never quiesced anything (which is also why clients stayed parked in the router until UFSDCLNP ran, the wedge behind the 2026-07-13 incident). Fixed with the proper double dereference plus an eye-catcher check.

**5. An orphaned SSCT redirects `S UFSD` to the master subsystem (deployment).**
While a subsystem named UFSD is registered, MVS converts `S UFSD` under **MSTR**, whose `IEFPDSI` knows only `SYS1.PROCLIB` — the start dies with `IEF612I PROCEDURE NOT FOUND` before any UFSD code runs. This is the real mechanism behind the documented "proc not found after abend" symptom (JES2 queues are clean; it is not a stuck-job issue). New `samplib/ufsdmstr` must be installed as `SYS1.PROCLIB(UFSD)`; SYSPRINT/SYSTERM/SYSUDUMP are DUMMY there because SYSOUT is unavailable under MSTR (S013-C0 otherwise, allocated by the C runtime for stdout).

## MVS verification (mvsdev, 2026-08-10)

Red (old build, from live console/MTT):
- `/C` → `UFSD098E` → `UFSD099I SHUTDOWN COMPLETE` → `IEF450I S222`; no 131I, no 097W (defects 3+4)
- orphan left with `ANCHOR_ACTIVE` **set**, SSVT entry live (defect 4)
- `S UFSD` over the orphan → `IEF612I`, twice, JES2 queues empty (defect 5); recovery required UFSDCLNP

Green (this branch promoted to UFSD.LINKLIB + SYS1.PROCLIB(UFSD) installed):
- `S UFSD` over an ACTIVE orphan → MSTR start → `UFSD002E ALREADY REGISTERED AND ACTIVE — NOT STARTING`, RC 8, no abend
- standalone UFSDCLNP vs ACTIVE orphan → `RECLAIM:` messages, ~4 s drain window, chain clean
- clean `S UFSD` → JES2 start, READY, no reclaim messages
- `/C` during transfers → `098E`, 3× `UFSD131I` superblock writeback (now runs on cancel!), **`UFSD097W … RECLAIMED AT NEXT START` as last message**, no 099I; orphan flags `20000000` (ACTIVE cleared)
- plain `S UFSD` over that orphan → `UFSD144I`–`148I RECLAIM:` + `UFSD004I ORPHANED PREDECESSOR RECLAIMED` → READY, exactly one UFSD SSCT in the chain
- `S UFSD` while running → `UFSD002E`, running instance unaffected (UFS download verified after)

## Message changes

- New: `UFSD002E`, `UFSD003E`, `UFSD004I`, `UFSD096E` (recovery cannot locate STC block)
- `UFSD143E`–`UFSD148I`, `UFSD152W`–`UFSD154I` now carry a `RECLAIM:` prefix and appear from both callers
- Abend path: `UFSD099I` dropped; `UFSD097W`/`UFSD098W` say `RECLAIMED AT NEXT START`

Docs updated: `docs/recovery.md` (procedure, MSTR-proc prerequisite, corrected IEF612I explanation, WTO reference), `README.md`, `samplib/ufsd`, new `samplib/ufsdmstr`.