### PR TITLE
Startup polish: # comments in parmlib, build stamp in the banner, one mount pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The server is configured through a Parmlib member referenced by the `UFSDPRM` DD
 
 | Statement | Parameters | Description |
 |-----------|-----------|-------------|
-| `ROOT` | `DSN` [, `SIZE`, `BLKSIZE`] | Root filesystem (always mounted at `/`, read-only for clients) |
+| `ROOT` | `DSN` [, `BLKSIZE`] | Root filesystem (always mounted at `/`, read-only for clients) |
 | `MOUNT` | `DSN`, `PATH`, `MODE`, `OWNER` | Additional filesystem mount |
 
 | Parameter | Values | Default | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,31 +6,35 @@ UFSD is configured through a Parmlib member, referenced by the `UFSDPRM` DD card
 
 ```
 /* Lines between slash-star are comments */
+# ... and so is a line starting with a hash
 
 ROOT     DSN(UFSD.ROOT)
 MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
 MOUNT    DSN(IBMUSER.UFSHOME)    PATH(/u/ibmuser)    MODE(RW) OWNER(IBMUSER)
 ```
 
-Comments are delimited by `/*` and `*/` (block comments, like JCL). Blank lines are ignored. Statements can span one line only.
+Comments come in two forms. `/*` … `*/` delimits a block comment (like JCL), and a `#` as the **first non-blank character** comments out the rest of that line — the usual way to disable a `MOUNT` temporarily.
+
+A `#` anywhere else on the line is **not** a comment and is treated as data. This is deliberate: the national characters `@ # $` are legal in MVS dataset names and qualifiers, so `DSN(SYS1.MY#LIB)` and a `PATH` containing a `#` must survive intact. There are no trailing comments.
+
+Blank lines are ignored. Statements can span one line only.
 
 ## ROOT Statement
 
 Defines the root filesystem, always mounted at `/`.
 
 ```
-ROOT     DSN(dataset.name) [SIZE(n)] [BLKSIZE(n)]
+ROOT     DSN(dataset.name) [BLKSIZE(n)]
 ```
 
 | Parameter | Values | Default | Description |
 |-----------|--------|---------|-------------|
 | `DSN(name)` | dataset name | — | **Required.** BDAM dataset for the root filesystem. |
-| `SIZE(n)` | `500K`, `1M`, etc. | — | Root disk size (used for auto-creation in a future release). |
 | `BLKSIZE(n)` | 512–8192 | `4096` | Block size in bytes. |
 
 The root filesystem is always read-only for clients. UFSD temporarily sets it read-write during startup to create mount-point directories, then switches it to read-only before accepting client requests.
 
-A size of 1 MB is sufficient for the root (it only holds mount-point directories).
+UFSD mounts what already exists; it never allocates or formats a disk. When you allocate the root dataset, 1 MB is enough — it holds nothing but mount-point directories. See [disk-setup.md](disk-setup.md) for allocating and formatting it.
 
 ## MOUNT Statement
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,279 @@
+# UFSD Installation Guide
+
+This guide installs **UFSD 1.0.0** on an MVS 3.8j system (TK4-, TK5, MVS/CE, or
+a custom Hercules build) from the release distribution archive.
+
+The archive contains:
+
+| File | Purpose |
+|------|---------|
+| `ufsd-1.0.0-load.xmit` | The load library (UFSD, UFSDSSIR, UFSDCLNP) as a TSO RECEIVE-ready XMIT |
+| `samplib/ufsd` | Started-task procedure for the UFSD server |
+| `samplib/ufsdclnp` | Started-task procedure for the emergency cleanup utility |
+| `samplib/ufsdprm0` | Sample PARMLIB configuration member |
+| `docs/installation.md` | This guide |
+
+The optional `ufsd-1.0.0-lib.tar.gz` (host `libufs.a` + headers) is only needed
+to **build client programs** — see [Building clients](#building-clients).
+
+---
+
+## 1. Prerequisites
+
+- **MVS 3.8j** on Hercules, up and IPLed.
+- A TSO userid with authority to update a PROCLIB (e.g. `SYS2.PROCLIB`) and a
+  PARMLIB (e.g. `SYS1.PARMLIB`), and to define a started task.
+- A 3270/TSO session for `RECEIVE` and operator commands.
+- A way to upload a **binary** file to the host (any one of: the mvslovers
+  ftpd, another FTP server, the mvsMF REST API, or a 3270 emulator with
+  IND$FILE — see step 2).
+
+UFSD runs as an **authorized started task** (it enters supervisor state for its
+CSA work). On the target MVS 3.8j systems (TK4-/TK5/MVS-CE) this is provided by
+the normal started-task security setup — no manual APF step is required.
+
+---
+
+## 2. Upload and RECEIVE the load library
+
+The `.xmit` is an EBCDIC NETDATA stream. Upload it **in binary** (no
+ASCII↔EBCDIC translation) into a **sequential dataset** with
+`RECFM=FB LRECL=80 BLKSIZE=3120`, then TSO `RECEIVE` it.
+
+How the target dataset gets created depends on the upload path: the mvslovers
+**ftpd** and **IND$FILE** create it for you (from the attributes you give);
+mvsMF and most other FTP servers need it **pre-allocated** first. Where a method
+says *pre-allocate*, allocate `IBMUSER.UFSD.XMIT` (TSO or ISPF 3.2) as
+`DSORG=PS, RECFM=FB, LRECL=80, BLKSIZE=3120`, primary ~50 tracks (secondary 20).
+
+Pick **one** upload method:
+
+### a) FTP — mvslovers/ftpd (no pre-allocation)
+
+If the system runs the mvslovers **ftpd** (default port 2121), just log in,
+switch to **binary**, and `put` — it creates the dataset for you:
+
+```
+ftp -P 2121 your-mvs-host
+> binary
+> put ufsd-1.0.0-load.xmit 'IBMUSER.UFSD.XMIT'
+> quit
+```
+
+(A `quote site …` is accepted but its parameters are ignored — you don't need
+it.)
+
+### b) mvsMF (z/OSMF-compatible REST API), via zowe
+
+If mvsMF is installed (e.g. you also run HTTPD/mvsMF) — the same path
+`make deploy` uses. mvsMF requires the dataset to **exist first**, so
+*pre-allocate* it, then:
+
+```
+zowe zos-files upload file-to-data-set ufsd-1.0.0-load.xmit "IBMUSER.UFSD.XMIT" --binary
+```
+
+### c) Another FTP server (pre-allocate)
+
+*Pre-allocate* the FB/80/3120 dataset, then transfer **binary** into it — a
+plain `binary` + `put`. Any `SITE` keywords for dataset attributes vary between
+MVS 3.8j TCP/IP stacks (they are **not** the z/OS syntax); pre-allocating makes
+them unnecessary.
+
+### d) IND$FILE (3270 emulator)
+
+No pre-allocation needed — IND$FILE creates the dataset from the attributes you
+give in the transfer. Use your emulator's file transfer in **binary** mode (no
+ASCII/CRLF translation) with `RECFM=FB LRECL=80 BLKSIZE=3120`. The exact option
+syntax is **client/emulator-dependent** — consult its file-transfer docs.
+
+### RECEIVE into the load library
+
+`RECEIVE` unloads the XMIT into the load library, allocating it (`RECFM=U`)
+from the attributes saved in the XMIT and restoring all three members. The
+reliable, unattended form is a batch step under IKJEFT01:
+
+```
+//RECV     EXEC PGM=IKJEFT01
+//SYSTSPRT DD  SYSOUT=*
+//SYSTSIN  DD  *
+  RECEIVE INDSN('IBMUSER.UFSD.XMIT') DATASET('UFSD.V1R0M0.LINKLIB')
+/*
+```
+
+`DATASET(...)` names the target explicitly. Omit it to accept the DSN saved in
+the XMIT (`UFSD.V1R0M0.LINKLIB`).
+
+Interactively from TSO READY you can instead enter `RECEIVE
+INDSN('IBMUSER.UFSD.XMIT')` and, when it prompts for restore parameters, press
+**Enter** to accept the default DSN or type `DATASET('your.chosen.linklib')`.
+
+Verify the three members are present:
+
+```
+ISPF 3.4 → UFSD.V1R0M0.LINKLIB  →  UFSD, UFSDSSIR, UFSDCLNP
+```
+
+Throughout the rest of this guide, replace `UFSD.V1R0M0.LINKLIB` with the DSN
+you actually restored to.
+
+---
+
+## 3. Install the started-task procedures
+
+Copy both procedures from the archive `samplib/` into your PROCLIB and point
+their `STEPLIB` at the load library from step 2.
+
+`SYS2.PROCLIB(UFSD)` — from `samplib/ufsd`:
+
+```
+//UFSD     PROC M=UFSDPRM0,D=SYS2.PARMLIB
+//UFSD     EXEC PGM=UFSD,REGION=4M,TIME=1440
+//STEPLIB  DD  DISP=SHR,DSN=UFSD.V1R0M0.LINKLIB      <- your load library
+//UFSDPRM  DD  DISP=SHR,DSN=&D(&M),FREE=CLOSE
+```
+
+`SYS2.PROCLIB(UFSDCLNP)` — from `samplib/ufsdclnp`:
+
+```
+//UFSDCLNP PROC
+//CLEANUP  EXEC PGM=UFSDCLNP
+//STEPLIB  DD  DISP=SHR,DSN=UFSD.V1R0M0.LINKLIB      <- your load library
+//SYSPRINT DD  SYSOUT=*
+```
+
+`M=` selects the PARMLIB member (default `UFSDPRM0`); `D=` selects the PARMLIB
+dataset. Install **both** procs — UFSDCLNP is the supported recovery path after
+an abend (see [step 7](#7-recovery)).
+
+---
+
+## 4. Configure PARMLIB
+
+Copy `samplib/ufsdprm0` to `SYS1.PARMLIB(UFSDPRM0)` (or the `D=` dataset you set
+above) and edit it for your site. The member declares the **root** filesystem
+and any additional **mounts**:
+
+```
+/* SYS1.PARMLIB(UFSDPRM0) */
+
+ROOT     DSN(UFSD.ROOT)
+
+MOUNT    DSN(HTTPD.WEBROOT)      PATH(/wwwroot)      MODE(RO)
+MOUNT    DSN(IBMUSER.UFSHOME)    PATH(/u/ibmuser)    MODE(RW) OWNER(IBMUSER)
+MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
+```
+
+- `ROOT` is required and is mounted on `/`.
+- `MOUNT` mode is `RO` or `RW`; `OWNER(userid)` restricts writes to one user.
+- Comments are `/* … */`, or a `#` in the first non-blank column of a line
+  (handy for disabling a `MOUNT`). A `#` elsewhere on the line is data, not a
+  comment — dataset names may contain one.
+
+Every `ROOT`/`MOUNT` dataset must **already exist and be UFS-formatted** before
+you start UFSD (it does **not** allocate or format disks). See the next step.
+The full keyword reference is in [configuration.md](configuration.md).
+
+---
+
+## 5. Create the UFS disk datasets
+
+Each mounted filesystem is a BDAM dataset holding a formatted UFS image. Create
+and upload them with **`ufsd-utils`** (from the `ufsd-utils` companion repo):
+
+```
+ufsd-utils create root.img --size 10M
+ufsd-utils upload root.img UFSD.ROOT
+```
+
+Repeat for each `MOUNT` dataset in your PARMLIB. The complete workflow
+(allocation attributes `DSORG=PS RECFM=U BLKSIZE=4096`, uploading content,
+geometry) is documented in [disk-setup.md](disk-setup.md).
+
+At minimum you need the **ROOT** dataset before the first start.
+
+---
+
+## 6. Start and verify
+
+```
+/S UFSD                     Start with the default member (UFSDPRM0)
+/S UFSD,M=UFSDPRM1           Start with an alternate member
+```
+
+A healthy start ends in `UFSD001I … READY` (messages are upper-case on the
+console):
+
+```
+UFSD000I UFSD 1.0.0 (A3F2C91) STARTING
+UFSD005I LIBC370 V1.0.2 (22B4870)
+UFSD030I CSA ALLOCATED: ANCHOR=00BDxxxx
+UFSD034I SSCT REGISTERED, SUBSYSTEM NAME=UFSD
+UFSD035I SSI ROUTER LOADED AT 00A8xxxx
+UFSD060I MOUNTED UFSD.ROOT ON / (ROOT)
+UFSD040I 3 FILESYSTEM(S) MOUNTED
+UFSD001I UFSD 1.0.0 READY -- 3 DISKS, 78K CSA, 64 SESSIONS, 256 FILES
+```
+
+The two build stamps identify exactly what is running: `UFSD000I` gives the
+UFSD version and the commit it was built from, `UFSD005I` the libc370 it was
+linked against — quote both in a bug report. A build made from a modified
+working tree marks its hash `-DIRTY` and adds `UFSD006W BUILT FROM A MODIFIED
+WORKING TREE`; a released build never does.
+
+Root reports as `(ROOT)`, not `RW`/`RO`: it is mounted read-write only long
+enough to create the mount-point directories, then switched to read-only
+before the first client can reach it. `UFSD040I` is a count — use
+`/F UFSD,MOUNT LIST` for the live per-filesystem detail.
+
+Operator commands:
+
+```
+/F UFSD,STATS               Status, mounts, request/error counters, IN FLIGHT
+/F UFSD,SESSIONS            List active client sessions
+/F UFSD,HELP                List all MODIFY commands
+/P UFSD                     Orderly stop
+```
+
+The full command reference is in [configuration.md](configuration.md).
+
+---
+
+## 7. Recovery
+
+A clean `/P UFSD` frees all CSA. After a **cancel (`/C UFSD`) or an abend**, the
+recovery handler deliberately retains the CSA; reclaim it before restarting by
+running UFSDCLNP:
+
+```
+/S UFSDCLNP                 (or submit it as a batch job, PGM=UFSDCLNP)
+/S UFSD
+```
+
+UFSDCLNP quiesces any in-flight clients, then frees the SSCT, the SSI router,
+the CSA pools and the anchor. Full recovery procedures and the complete WTO
+message reference are in [recovery.md](recovery.md).
+
+---
+
+## Building clients
+
+To build a client (HTTPD, FTPD, or your own program) against UFSD, unpack
+`ufsd-1.0.0-lib.tar.gz` — it provides `include/` (the `libufs`/`ufsd` headers)
+and `lib/libufs.a` for the cc370 host build. The `libufs` C API and the
+assembler linkage convention are documented in
+[development.md](development.md).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `S806` (module not found) at `/S UFSD` | `STEPLIB` DSN in the proc does not match the RECEIVE'd load library, or the members did not restore |
+| `/S UFSD` rejected — procedure not found | Proc not copied into a PROCLIB in the started-task concatenation |
+| `UFSD061E PARMLIB … NOT FOUND` | `UFSDPRM` DD / member missing, or `D=`/`M=` wrong |
+| Mount fails / `UFSD124E` superblock validation | The `ROOT`/`MOUNT` dataset does not exist or is not UFS-formatted — create it first (step 5) |
+| `S106` at start on a freshly restored library | The load modules were corrupted in transit — re-RECEIVE from a fresh **binary** upload |
+
+For diagnostics and the message-ID reference, see [recovery.md](recovery.md).

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -45,7 +45,9 @@ Startup detects the orphaned predecessor itself (`ufsd_reclaim()`, shared with U
 
 **Prerequisite: `SYS1.PROCLIB(UFSD)` must be installed** (`samplib/ufsdmstr`). While a UFSD SSCT is registered, MVS converts `S UFSD` under the **master subsystem** — the subsystem name matches — and the master's `IEFPDSI` knows only `SYS1.PROCLIB`. Without the companion member the start fails with `IEF612I PROCEDURE NOT FOUND` before any UFSD code runs (this is the real mechanism behind the long-observed "proc not found after abend" symptom). After a clean stop no SSCT exists and the start goes through JES2 and `SYS2.PROCLIB(UFSD)` as usual.
 
-Console output of a start over an orphan (MVS-verified 2026-08-10):
+Console output of a start over an orphan (MVS-verified 2026-08-10, captured
+before the #51 banner change — `UFSD000I` now also carries the build commit
+and is followed by `UFSD005I`; the reclaim sequence itself is unchanged):
 
 ```
 UFSD000I UFSD 1.1.0 STARTING
@@ -141,11 +143,13 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 
 | Message | Severity | Description |
 |---------|----------|-------------|
-| UFSD000I | I | UFSD starting (version) |
+| UFSD000I | I | UFSD starting — version + build commit (`-DIRTY` when built from a modified tree) |
 | UFSD001I | I | Ready — version + CSA/session/file summary |
 | UFSD002E | E | Predecessor SSCT found with ACTIVE anchor — refusing to start (run UFSDCLNP if orphaned) |
 | UFSD003E | E | Predecessor reclaim failed (supervisor state) — startup fails |
 | UFSD004I | I | Orphaned predecessor reclaimed at startup — CSA recovered |
+| UFSD005I | I | libc370 version + commit this module was linked against |
+| UFSD006W | W | Built from a modified working tree — issued only by a `-DIRTY` build |
 | UFSD030I | I | CSA anchor allocated |
 | UFSD031I–033I | I | Pool sizes (request pool / buffer pool / trace buffer) |
 | UFSD034I | I | SSCT registered |
@@ -153,8 +157,7 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD045I | I | Session table allocated |
 | UFSD047I | I | Global file table allocated |
 | UFSD040I | I | Mount summary (n filesystems mounted) |
-| UFSD041I | I | Individual mount detail (path, DSN, mode, owner) |
-| UFSD060I | I | Mounted DSN on path |
+| UFSD060I | I | Mounted DSN on path — mode `RW`/`RO`, or `ROOT` for `/` |
 | UFSD090E | E | Cannot initialize console interface (startup fails) |
 | UFSD091E | E | APF setup failed — STEPLIB not APF-authorized (startup fails) |
 | UFSD092E | E | Cannot allocate CSA anchor (startup fails) |
@@ -176,19 +179,23 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | Message | Severity | Description |
 |---------|----------|-------------|
 | UFSD061E | E | Parmlib not found |
-| UFSD062I | I | Parmlib config dump (ROOT/MOUNT listing) |
 | UFSD076I | I | Inode cache refill complete |
 | UFSD122W | W | Cannot create mount point |
 | UFSD123W | W | Cannot mount dataset |
 
-### Sessions and Operations (100–119)
+### Parmlib Parser (100–105)
+
+Issued by the `DD:UFSDPRM` parser at startup. A rejected statement is
+skipped; the rest of the member is still processed.
 
 | Message | Severity | Description |
 |---------|----------|-------------|
-| UFSD100I | I | Session opened |
-| UFSD101I | I | Session closed |
-| UFSD110I | I | Sessions list (from /F UFSD,SESSIONS) |
-| UFSD111I | I | Session pruned (stale ASID) |
+| UFSD100W | W | Cannot open DD:UFSDPRM — using defaults |
+| UFSD101W | W | Too many MOUNT statements — the rest are ignored |
+| UFSD102W | W | MOUNT without DSN() — statement skipped |
+| UFSD103W | W | MOUNT without PATH() — statement skipped |
+| UFSD104W | W | Unrecognized statement (first 40 characters echoed) |
+| UFSD105W | W | ROOT statement missing — startup fails |
 
 ### Reclaim and UFSDCLNP (140–149, 152–154)
 

--- a/docs/ufsdisk-spec.md
+++ b/docs/ufsdisk-spec.md
@@ -450,10 +450,11 @@ the root disk (one `ddname=NAME  path  type` entry per line).
 **UFSD (current):** UFSD does **not** read `/etc/fstab`. Mounts are
 configured in a PARMLIB member `SYS1.PARMLIB(UFSDPRMx)` (or `SYS2`, per
 the standard PARMLIB search order), read via `DD:UFSDPRM` at startup.
-The member uses keyword statements; comments are `/* … */` blocks:
+The member uses keyword statements; comments are `/* … */` blocks or a
+line starting with `#`:
 
 ```
-ROOT   DSN(UFSD.ROOT)       SIZE(1M)  BLKSIZE(4096)
+ROOT   DSN(UFSD.ROOT)       BLKSIZE(4096)
 MOUNT  DSN(HTTPD.WEBROOT)   PATH(/wwwroot) MODE(RO)
 MOUNT  DSN(USER.HOME)       PATH(/u/USER)  MODE(RW) OWNER(USER)
 ```

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -197,7 +197,6 @@ struct ufsd_mount_cfg {
 
 struct ufsd_config {
     char             root_dsname[45];
-    unsigned         root_size;       /* bytes (from SIZE param)  */
     unsigned         root_blksize;    /* block size (default 4096)*/
     unsigned         nmounts;
     UFSD_MOUNT_CFG   mounts[UFSD_CFG_MAX_MOUNTS];
@@ -611,7 +610,6 @@ int           ufsd_disk_umount(UFSD_STC *stc,
 
 /* ufsd#cfg.c (AP-3a) -- parmlib configuration */
 int           ufsd_cfg_read(UFSD_CONFIG *cfg)                        asm("UFSD@CFR");
-void          ufsd_cfg_dump(const UFSD_CONFIG *cfg)                  asm("UFSD@CFD");
 
 /* ufsd#blk.c (AP-1e) -- BDAM block I/O */
 int  ufsd_blk_read(UFSD_DISK *disk, unsigned sector, void *buf)      asm("UFSD@BRD");

--- a/project.toml
+++ b/project.toml
@@ -6,7 +6,24 @@ type = "application"
 [build]
 # -DVERSION feeds ufsd.c's `#ifndef VERSION` (otherwise the hardcoded
 # fallback). v1's mbt injected it automatically; v2 does not.
-cflags = ["-I", "include", '-DVERSION=\"$(PROJECT_VERSION)\"']
+#
+# -DCOMMIT / -DCOMMIT_DIRTY are the build stamp behind UFSD000I/UFSD006W.
+# "-dirty" counts TRACKED modifications only (--untracked-files=no): stray
+# notes and generated files are not a provenance difference. Outside a git
+# checkout -- a source tarball -- the hash degrades to "unknown" rather
+# than failing the build.
+#
+# Caveat: both are baked into ufsd.o, which mbt recompiles only when
+# ufsd.c or one of its headers changes, so a local incremental build made
+# after a commit can still carry the previous hash. Release and CI builds
+# start from a clean tree, so a packaged banner is always accurate; `make
+# clean` restores it locally. The general fix belongs in mbt.mk.
+cflags = [
+    "-I", "include",
+    '-DVERSION=\"$(PROJECT_VERSION)\"',
+    '-DCOMMIT=\"$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)$(shell git status --porcelain --untracked-files=no 2>/dev/null | grep -q . && echo -dirty)\"',
+    '-DCOMMIT_DIRTY=$(shell git status --porcelain --untracked-files=no 2>/dev/null | grep -q . && echo 1 || echo 0)',
+]
 
 # ── Load modules ─────────────────────────────────────────
 # UFSD — main daemon (threading → crt1)

--- a/samplib/ufsdprm0
+++ b/samplib/ufsdprm0
@@ -14,3 +14,7 @@ MOUNT    DSN(MVSCE02.UFSHOME)    PATH(/u/mvsce02)    MODE(RW) OWNER(MVSCE02)
 
 /* Shared scratch area, writable by any authenticated user */
 MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
+
+/* A '#' in the first non-blank column comments a line out.  It must be
+   first: '#' is legal inside a dataset name, so it is data anywhere else. */
+# MOUNT    DSN(UFSD.ARCHIVE)      PATH(/archive)      MODE(RO)

--- a/src/ufsd#cfg.c
+++ b/src/ufsd#cfg.c
@@ -2,13 +2,12 @@
 **
 ** AP-3a: Read and parse SYS1.PARMLIB(UFSDPRMx) via DD:UFSDPRM.
 **
-** Config syntax (comments delimited by slash-star):
-**   ROOT   DSN(SYS1.UFSD.ROOT) SIZE(1M) BLKSIZE(4096)
+** Config syntax (comments delimited by slash-star, or a leading '#'):
+**   ROOT   DSN(SYS1.UFSD.ROOT) BLKSIZE(4096)
 **   MOUNT  DSN(HTTPD.WEBROOT)  PATH(/www) MODE(RO)
 **   MOUNT  DSN(USER.HOME)      PATH(/u/USER) MODE(RW) OWNER(USER)
 **
 ** ufsd_cfg_read   read config from DD:UFSDPRM
-** ufsd_cfg_dump   WTO summary of parsed config
 */
 
 #include "ufsd.h"
@@ -143,6 +142,13 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
         while (isspace((unsigned char)*p)) p++;
         if (*p == '\0') continue;
 
+        /* Full-line comment: '#' as the first non-blank character.
+        ** Deliberately NOT honoured anywhere else on the line: the
+        ** national characters @ # $ are legal in MVS dataset names and
+        ** qualifiers, so DSN(SYS1.MY#LIB) -- and a PATH holding a '#' --
+        ** must survive intact.  A trailing comment would truncate both. */
+        if (*p == '#') continue;
+
         /* Start of block comment */
         if (p[0] == '/' && p[1] == '*') {
             if (!strstr(p + 2, "*/"))
@@ -154,8 +160,6 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
         if (strncmp(p, "ROOT", 4) == 0 && isspace((unsigned char)p[4])) {
             if (parse_param(p, "DSN", val, sizeof(val)))
                 strncpy(cfg->root_dsname, val, 44);
-            if (parse_param(p, "SIZE", val, sizeof(val)))
-                cfg->root_size = parse_size(val);
             if (parse_param(p, "BLKSIZE", val, sizeof(val)))
                 cfg->root_blksize = parse_size(val);
             if (cfg->root_blksize == 0)
@@ -212,34 +216,4 @@ ufsd_cfg_read(UFSD_CONFIG *cfg)
     }
 
     return 0;
-}
-
-/* ============================================================
-** ufsd_cfg_dump
-**
-** WTO summary of parsed configuration.
-** ============================================================ */
-void
-ufsd_cfg_dump(const UFSD_CONFIG *cfg)
-{
-    unsigned i;
-
-    if (!cfg) return;
-
-    wtof("UFSD110I CONFIG: ROOT DSN=%s SIZE=%u BLKSIZE=%u",
-         cfg->root_dsname, cfg->root_size, cfg->root_blksize);
-
-    for (i = 0; i < cfg->nmounts; i++) {
-        const UFSD_MOUNT_CFG *m = &cfg->mounts[i];
-
-        if (m->owner[0])
-            wtof("UFSD111I CONFIG: MOUNT DSN=%s PATH=%s %s OWNER=%s",
-                 m->dsname, m->path,
-                 m->mode == UFSD_MOUNT_RW ? "RW" : "RO",
-                 m->owner);
-        else
-            wtof("UFSD111I CONFIG: MOUNT DSN=%s PATH=%s %s",
-                 m->dsname, m->path,
-                 m->mode == UFSD_MOUNT_RW ? "RW" : "RO");
-    }
 }

--- a/src/ufsd#ini.c
+++ b/src/ufsd#ini.c
@@ -483,15 +483,28 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
 
     stc->disks[stc->ndisks++] = disk;
 
-    if (disk->mount_owner[0])
-        wtof("UFSD060I MOUNTED %s ON %s (%s, OWNER=%s)",
-             disk->dsn, disk->mountpath,
-             mode == UFSD_MOUNT_RW ? "RW" : "RO",
-             disk->mount_owner);
-    else
-        wtof("UFSD060I MOUNTED %s ON %s (%s)",
-             disk->dsn, disk->mountpath,
-             mode == UFSD_MOUNT_RW ? "RW" : "RO");
+    /* Report the root as (ROOT), not (RW).  Root is mounted RW purely so
+    ** ufsd_ufs_init can create the mount-point directories, and is flipped
+    ** to RO before any client can reach it -- printing RW here would state
+    ** the opposite of what clients see.  The test is on the mount path,
+    ** not on UFSD_DISK_ROOT: that flag is set by our caller, after this
+    ** WTO.  Only '/' can be the root, and a second mount on '/' is already
+    ** rejected as a duplicate above. */
+    {
+        const char *modestr;
+
+        if (strcmp(disk->mountpath, "/") == 0)
+            modestr = "ROOT";
+        else
+            modestr = (mode == UFSD_MOUNT_RW) ? "RW" : "RO";
+
+        if (disk->mount_owner[0])
+            wtof("UFSD060I MOUNTED %s ON %s (%s, OWNER=%s)",
+                 disk->dsn, disk->mountpath, modestr, disk->mount_owner);
+        else
+            wtof("UFSD060I MOUNTED %s ON %s (%s)",
+                 disk->dsn, disk->mountpath, modestr);
+    }
 
     return 0;
 }
@@ -568,8 +581,6 @@ ufsd_ufs_init(UFSD_STC *stc)
         return 8;
     }
 
-    ufsd_cfg_dump(&cfg);
-
     /* Mount root filesystem via DYNALLOC */
     rc = ufsd_disk_mount_dyn(stc, cfg.root_dsname, "/",
                              UFSD_MOUNT_RW, "");
@@ -632,24 +643,11 @@ ufsd_ufs_init(UFSD_STC *stc)
     /* Root is now RO for clients — all mountpoints are created */
     root->mount_mode = UFSD_MOUNT_RO;
 
+    /* Count only.  Each disk already announced itself with UFSD060I as it
+    ** was mounted, so a second pass over the same list would just repeat
+    ** it; /F UFSD,MOUNT LIST prints the live state (path, DSN, mode,
+    ** owner) on demand. */
     wtof("UFSD040I %u FILESYSTEM(S) MOUNTED", stc->ndisks);
-    for (i = 0; i < stc->ndisks; i++) {
-        UFSD_DISK *d = stc->disks[i];
-        if (!d) continue;
-        if (d->flags & UFSD_DISK_ROOT)
-            wtof("UFSD041I   %s DSN=%s (ROOT, %s)",
-                 d->mountpath, d->dsn,
-                 d->mount_mode == UFSD_MOUNT_RW ? "RW" : "RO");
-        else if (d->mount_owner[0])
-            wtof("UFSD041I   %s DSN=%s (%s, OWNER=%s)",
-                 d->mountpath, d->dsn,
-                 d->mount_mode == UFSD_MOUNT_RW ? "RW" : "RO",
-                 d->mount_owner);
-        else
-            wtof("UFSD041I   %s DSN=%s (%s)",
-                 d->mountpath, d->dsn,
-                 d->mount_mode == UFSD_MOUNT_RW ? "RW" : "RO");
-    }
 
     return 0;
 }

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -45,15 +45,51 @@
 **   (unconditional) fallback.
 */
 
+/* Build stamp (Issue #51).  All three are injected by project.toml:
+** VERSION from the project version, COMMIT from `git rev-parse --short
+** HEAD` (with "-dirty" appended when a TRACKED file differs from HEAD),
+** COMMIT_DIRTY as the matching 0/1 flag.  The fallbacks keep a build
+** outside make -- or outside a git checkout -- compiling. */
 #ifndef VERSION
 #define VERSION "1.0.0-dev"
 #endif
+#ifndef COMMIT
+#define COMMIT "unknown"
+#endif
+#ifndef COMMIT_DIRTY
+#define COMMIT_DIRTY 0
+#endif
 
 #include "ufsd.h"
+#include <ctype.h>
 #include <string.h>
 #include <clibos.h>
-#include <clibwto.h>
 #include <clibstae.h>
+#include <clibver.h>
+#include <clibwto.h>
+
+/* upcase -- copy `src` into `dst` in upper case, NUL-terminated, writing
+** at most `n` bytes including the NUL.  Returns `dst` so a call can be
+** used directly as a wtof() argument.
+**
+** The console house style is upper case, but every build stamp arrives in
+** lower case: VERSION and COMMIT carry the project version and a hex
+** commit hash, and libc370_version() returns a whole sentence of its own
+** ("libc370 v1.0.2-dev (22b4870)").  toupper() is the libc370 one, so the
+** mapping is EBCDIC-correct -- do not hand-roll a range test here. */
+static const char *
+upcase(char *dst, unsigned n, const char *src)
+{
+    unsigned i;
+
+    if (n == 0) return dst;
+
+    for (i = 0; i + 1U < n && src[i]; i++)
+        dst[i] = (char)toupper((unsigned char)src[i]);
+    dst[i] = '\0';
+
+    return dst;
+}
 
 /* ============================================================
 ** ufsd_recover
@@ -269,6 +305,7 @@ main(int argc, char **argv)
     unsigned     *ecblist[3]; /* WAIT ECBLIST: up to 2 entries + sentinel */
     unsigned      count;
     int           rc;
+    char          vers[24];   /* VERSION, upper case -- UFSD000I + UFSD001I */
 
     (void)argc;
 
@@ -297,7 +334,24 @@ main(int argc, char **argv)
     /* --- ESTAE recovery ------------------------------------------ */
     __estae(ESTAE_CREATE, ufsd_recover, &ufsd);
 
-    wtof("UFSD000I UFSD %s STARTING", VERSION);
+    /* --- Startup banner ------------------------------------------- */
+    /* Which UFSD, built from which source, against which C runtime.  A
+    ** deploy/relink mismatch (sysroot says X, the STC runs Y) then cannot
+    ** hide, and a build carrying uncommitted changes says so instead of
+    ** passing itself off as the commit it was branched from.  The commit
+    ** buffers are scoped: they are dead the moment the banner is out. */
+    upcase(vers, sizeof(vers), VERSION);
+    {
+        char commit[24];
+        char stamp[48];
+
+        wtof("UFSD000I UFSD %s (%s) STARTING",
+             vers, upcase(commit, sizeof(commit), COMMIT));
+        wtof("UFSD005I %s", upcase(stamp, sizeof(stamp), libc370_version()));
+#if COMMIT_DIRTY
+        wtof("UFSD006W BUILT FROM A MODIFIED WORKING TREE");
+#endif
+    }
 
     /* --- Predecessor reclaim (Issue #49) -------------------------- */
     /* After an abend the ESTAE path frees nothing: SSCT, router module
@@ -421,7 +475,7 @@ main(int argc, char **argv)
              (unsigned)sizeof(UFSD_ANCHOR) + 1023U) / 1024U;
         wtof("UFSD001I UFSD %s READY -- %u DISKS, %uK CSA, "
              "%u SESSIONS, %u FILES",
-             VERSION, ufsd.ndisks, csa_kb,
+             vers, ufsd.ndisks, csa_kb,
              (unsigned)UFSD_MAX_SESSIONS, (unsigned)UFSD_MAX_GFILES);
     }
 


### PR DESCRIPTION
Fixes #51

Four items on the startup path, each too small for its own PR.

## What changed

**1. `#` as a full-line comment in the parmlib.** Honoured only as the first non-blank character on the line. The national characters `@ # $` are legal in MVS dataset names and qualifiers, so `DSN(SYS1.MY#LIB)` — and a `PATH` holding a `#` — must survive intact; a trailing comment would truncate both, so there is none. The check sits after the block-comment state test, so a `#` inside `/* … */` stays unreachable.

**2. Build provenance in the banner** (format picked from four rendered options):

```
UFSD000I UFSD 1.1.0-DEV (A3F2C91) STARTING
UFSD005I LIBC370 V1.0.2-DEV (22B4870)
UFSD006W BUILT FROM A MODIFIED WORKING TREE     <- dirty builds only
```

`-DCOMMIT` / `-DCOMMIT_DIRTY` are injected the same way `-DVERSION` already was. `-dirty` counts **tracked** modifications only; outside a git checkout the hash degrades to `unknown`. Both stamps arrive lower case and the console house style is upper, so they go through libc370's (EBCDIC-correct) `toupper()`.

**3. One pass over the disk list instead of three.** 11 lines → 6 for a 3-disk config. `UFSD110I`/`UFSD111I` (parsed intent) and `UFSD041I` (per-disk summary) are gone; `UFSD060I` per disk plus the `UFSD040I` count remain, and `/F UFSD,MOUNT LIST` (`UFSD068I`/`UFSD069I`) still prints live per-filesystem state on demand. Root now reports `(ROOT)` instead of `(RW)` — it is RW only long enough to create the mount points and is read-only before any client sees it. The test is on the mount path, not `UFSD_DISK_ROOT`: that flag is set by the caller, *after* the WTO.

**4. `ROOT … SIZE(n)` removed.** Parsed and stored, never read. `parse_size()` stays — `BLKSIZE` needs it.

## Decisions worth a second opinion

- **Stale-stamp window (accepted, not fixed here).** `-DCOMMIT` bakes into `ufsd.o`, which mbt recompiles only when `ufsd.c` or one of its headers changes, so a **local incremental** build made after a commit can still carry the previous hash. Release and CI builds start from a clean tree, so a packaged banner is always accurate. The general fix belongs in `mbt.mk` — filed as mvslovers/mbt#59.
- **No unit test for the parser.** `ufsd_cfg_read()` opens `DD:UFSDPRM` and pulls in `clibwto.h`, so it cannot run under `make test-host` without refactoring it to take a `FILE*` — scope creep on a cleanup issue, so it was not done. Flagging this explicitly rather than letting the project's verification rule pass silently.
- **`docs/recovery.md` had four rows for messages no code issues** (`UFSD062I`, and `UFSD100I`/`101I`/`110I`/`111I` documented as session messages). The 100–105 range is actually the parmlib parser and is now documented as such. Beyond the issue's literal ask — easy to revert if you'd rather keep it separate.
- **`docs/installation.md`** was untracked work-in-progress; its sample startup log showed the pre-#51 banner and `MOUNTED UFSD.ROOT ON / (RW)`. Updated and brought into this PR by decision during implementation.
- **`docs/recovery.md`'s MVS-verified reclaim capture is left verbatim** with a note that it predates this banner change, rather than editing a captured log into something that was never observed.

## Verification

Host build plus a full deploy/activate/restart cycle on the mvsdev stand (2026-08-10).

- `make clean && make all` green, `-Wall -Werror`, no new warnings; `make test-host` 131/131.
- Both build configurations compiled and inspected in the generated object/assembler:
  - clean tree → `-DCOMMIT=\"cd5be7f\"`, `-DCOMMIT_DIRTY=0`, no `UFSD006W` emitted;
  - dirty tree → `-DCOMMIT=\"04f4fed-dirty\"`, `-DCOMMIT_DIRTY=1`, `UFSD006W` emitted.
- `libc370_version()` resolves through autocall (`LIBC370@` external, `@@ver.o` in the sysroot `libc.a`) — the link is the proof.
- `upcase()` bounds-checked on the host at the exact buffer sizes `main()` uses (truncation stops at n-1, no overrun, `n == 0` writes nothing).

### On MVS 3.8j

`make deploy` → `UFSDACT` (CC 0000, both steps) → `/P UFSD` → `/S UFSD`. The stop freed all CSA (`UFSD096I`, `UFSD099I`), so nothing was retained and no `UFSDCLNP` was needed. The start:

```
UFSD000I UFSD 1.1.0-DEV (CD5BE7F) STARTING
UFSD005I LIBC370 V1.0.2-DEV (67FF430)
...
UFSD060I MOUNTED UFSD.ROOT ON / (ROOT)
UFSD060I MOUNTED HTTPD.WWWROOT ON /wwwroot (RW)
UFSD060I MOUNTED UFSD.SCRATCH ON /tmp (RW)
UFSD040I 3 FILESYSTEM(S) MOUNTED
UFSD001I UFSD 1.1.0-DEV READY -- 3 DISKS, 78K CSA, 64 SESSIONS, 256 FILES
```

`CD5BE7F` is this branch's commit, which is what makes the stamp worth having: it proves the running module is the new build rather than relying on the version string, whose staleness `UFSDACT` explicitly warns about. Clean tree, so no `-DIRTY` and no `UFSD006W` — the `COMMIT_DIRTY=0` path is exercised end to end. `/F UFSD,MOUNT LIST` still prints the per-filesystem detail (`UFSD069I`, root correctly `RO` there), which is what justifies dropping `UFSD041I`.

### Parser, on MVS

The production `SYS2.PARMLIB(UFSDPRM0)` on that stand already carries three `#`-commented `MOUNT` lines — the exact input from the issue's symptom. The start above parsed it with **no `UFSD104W`** and mounted 3 filesystems.

The safety property was checked with a separate member (`UFSDPRMT`, started via `S UFSD,M=UFSDPRMT`; the production member was never modified and the test member was deleted afterwards):

```
# MOUNT    DSN(UFSD.SCRATCH)       PATH(/tmp)          MODE(RW)
    # AN INDENTED HASH IS A COMMENT TOO -- FIRST NON-BLANK COUNTS
MOUNT    DSN(UFSD.SCR#TCH)       PATH(/tmp)          MODE(RW)
```

gave:

```
UFSD060I MOUNTED UFSD.ROOT ON / (ROOT)
UFSD060I MOUNTED HTTPD.WWWROOT ON /wwwroot (RW)
UFSD120E DYNALLOC FAILED FOR DSN=UFSD.SCR#TCH (S99ERR=1708: Dataset not cataloged)
UFSD123W CANNOT MOUNT DSN=UFSD.SCR#TCH ON /tmp
UFSD040I 2 FILESYSTEM(S) MOUNTED
```

Three things at once: the full-line `#` was skipped (2 filesystems, not 3, and no `UFSD104W`), the indented `#` was skipped too, and `UFSD.SCR#TCH` reached DYNALLOC **intact**. That last line is the discriminating evidence — had `#` been honoured mid-line, the statement would have been truncated to `MOUNT DSN(UFSD.SCR` and produced `UFSD102W MOUNT MISSING DSN()` instead.

