### PR TITLE
Refuse to reclaim a UFSD whose address space is still there (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ make link           # mvslink on MVS
 | UFSD#FIL | `src/ufsd#fil.c` | File dispatch |
 | UFSD#GFT | `src/ufsd#gft.c` | Global file table |
 | UFSD#TRC | `src/ufsd#trc.c` | Trace ring buffer |
+| UFSD#RCL | `src/ufsd#rcl.c` | Orphan reclaim + liveness guard (startup + UFSDCLNP) |
+| UFSD#ASV | `src/ufsd#asv.c` | ASVT membership scan (portable, host-tested) |
 
 Client: `client/libufs.c` (stub library — includes ufs_stat), `client/libufstst.c` (integration test)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,7 +175,9 @@ No Cross-Memory Services (PC/PT) are available on S/370. The IPC uses IEFSSREQ (
 | UFSD#FIL | `src/ufsd#fil.c` | 1464 | File operation dispatch |
 | UFSD#GFT | `src/ufsd#gft.c` | 119 | Global File Table |
 | UFSD#TRC | `src/ufsd#trc.c` | 109 | Trace ring buffer |
-| UFSDCLNP | `src/ufsdclnp.c` | 198 | Emergency cleanup (no-IPL recovery) |
+| UFSD#RCL | `src/ufsd#rcl.c` | 274 | Orphan reclaim + liveness guard (shared by startup and UFSDCLNP) |
+| UFSD#ASV | `src/ufsd#asv.c` | 36 | ASVT membership scan (portable, host-tested) |
+| UFSDCLNP | `src/ufsdclnp.c` | 70 | Emergency cleanup (no-IPL recovery) |
 | LIBUFS | `client/libufs.c` | 1010 | Client stub library |
 | LIBUFTST | `client/libufstst.c` | 345 | Integration test client |
 | **Total** | | **~7600** | Server + client |

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -64,7 +64,9 @@ UFSD030I CSA ALLOCATED: ANCHOR=...
 precedes `UFSD145I` while they bail; a count still standing after the
 ceiling yields `UFSD152W … ASSUMING LEAKED, FREEING` and reclaim proceeds.)
 
-Startup refuses to reclaim a predecessor whose anchor is still flagged ACTIVE (`UFSD002E UFSD ALREADY REGISTERED AND ACTIVE`) — every shutdown path clears the flag before the STC ends, so a set flag means a UFSD instance is (or appears to be) still running. If the instance is genuinely gone (e.g. after a FORCE, where the ESTAE never ran), use the standalone fallback, which reclaims unconditionally:
+This covers the FORCE case too. A UFSD killed before its ESTAE could run leaves `UFSD_ANCHOR_ACTIVE` set, which used to make startup refuse; since #53 the reclaim looks the anchor's `server_ascb` up in the ASVT, finds no such address space, and reclaims the orphan anyway. `/S UFSD` is the answer to every abnormal end of a UFSD instance.
+
+What startup still refuses is a predecessor that is genuinely **running** (`UFSD155W` names its ASCB, then `UFSD002E UFSD ALREADY REGISTERED AND ACTIVE`) — as it must; two servers cannot own the same CSA. The one remaining case for the standalone utility is an anchor flagged ACTIVE whose ASCB cannot be checked at all (`UFSD156W`), which needs the `force` only UFSDCLNP passes:
 
 ```
 /S UFSDCLNP
@@ -86,7 +88,29 @@ The drain (step 2) mirrors the clean-`/P` path and closes the window where freei
 
 UFSDCLNP is safe to run when UFSD is not registered — it reports "nothing to do" and exits RC=0.
 
-**Important:** Do not run UFSDCLNP while UFSD is *healthy and active*. It clears `UFSD_ANCHOR_ACTIVE` and frees the CSA, which pulls the storage out from under the running STC — an S0C4 in UFSD itself. The drain protects in-flight *clients* during recovery; it does not detect a live server. UFSDCLNP is for the post-abend case where the STC is already gone.
+### The Liveness Guard (#53)
+
+Steps 1–6 are exactly what must never happen to a *running* UFSD: clearing `UFSD_ANCHOR_ACTIVE` and freeing the CSA pulls the storage out from under the live STC. Before #53, UFSDCLNP had no way to tell the two apart and did it anyway.
+
+It now refuses. Before touching anything, the reclaim takes the STC's ASCB from the anchor (`server_ascb`, recorded at startup for cross-AS POST) and looks it up in the ASVT. Only an ASCB that belongs to no currently assigned address space is treated as an orphan's:
+
+| Anchor state | `/S UFSD` (reclaim) | `/S UFSDCLNP` (`force`) |
+|---|---|---|
+| ACTIVE clear — a shutdown path ran | reclaims | reclaims |
+| ACTIVE, ASCB assigned in the ASVT | refuses (`UFSD155W` + `UFSD002E`) | refuses (`UFSD155W` + `UFSD157W`, RC 8) |
+| ACTIVE, ASCB in no ASVT entry — killed before the ESTAE ran | reclaims | reclaims |
+| ACTIVE, ASCB is the reclaiming address space's own | reclaims | reclaims |
+| ACTIVE, no ASCB to look up | refuses (`UFSD156W` + `UFSD002E`) | reclaims |
+
+So `force` no longer means "unconditionally": it covers only the last row. A running server is off limits to UFSDCLNP as well, and there is no override — stop it first.
+
+Row four is what makes the FORCE recovery work at all, and it is not a corner case. An ASCB block goes back to SQA when its address space ends, and the address space created next — usually the restart itself — can be handed the same block. Measured on mvsdev: UFSD ran in ASCB `00FD40D0`, was killed, and the restart came up in `00FD40D0` again. Without excluding the caller's own ASCB, that restart would find the predecessor's address in the ASVT, assigned to itself, and refuse — and so would UFSDCLNP, leaving only an IPL. The exclusion cannot hide a live server: two address spaces alive at the same time never share an ASCB address.
+
+Row three is rarer than it looks, because MVS makes it hard to produce: `FORCE` is rejected for a cancelable address space (`IEE838I … CANCELABLE - ISSUE CANCEL BEFORE FORCE`), and a `CANCEL` reaches UFSD's ESTAE, which clears the flag on its way out. The state therefore arises from a UFSD hung badly enough that the CANCEL never completes, or from the `UFSD097E` path where shutdown cannot enter supervisor state.
+
+The comparison is on the ASCB address alone; nothing is read out of the ASCB itself, because SQA storage of an ended address space can be reused and a jobname read out of a reused block would be another address space's. That leaves one residual error, and it is the harmless one: if the ASCB address has been handed to some *third* address space, a genuinely dead UFSD looks alive and cleanup is refused. Check with `D A,L` — if no UFSD address space is listed, the SSCT is an orphan the guard cannot recognize, and an IPL is the way out.
+
+**A hung but living UFSD is not a UFSDCLNP case.** The guard sees an assigned ASCB and refuses regardless of whether the server still answers. Take the address space down first (`/P UFSD`, then `/C UFSD`, then FORCE), and only then reclaim — after a FORCE, `/S UFSD` already does it.
 
 ### Installation
 
@@ -104,7 +128,7 @@ Note that the name is compiled into every client through the statically linked l
 
 The rename is not backward compatible in either direction — a 1.0.0 client cannot find `UFS1`, and a 1.1.0 server does not see an SSCT named `UFSD`. On a system that ran UFSD 1.0.0:
 
-1. Stop the server cleanly (`/P UFSD`). If it is already gone but left an orphan behind, run `/S UFSDCLNP` **with the old load modules still installed** — its reclaim looks for the old name, and once the new modules are in place nothing will find that SSCT again. An IPL clears it just as well.
+1. Stop the server cleanly (`/P UFSD`) — the stop is not optional, since UFSDCLNP refuses while the address space is still there (see [The Liveness Guard](#the-liveness-guard-53)). If it is already gone but left an orphan behind, run `/S UFSDCLNP` **with the old load modules still installed** — its reclaim looks for the old name, and once the new modules are in place nothing will find that SSCT again. An IPL clears it just as well.
 2. Delete `SYS1.PROCLIB(UFSD)` if the MSTR companion was installed. It is no longer needed, and left in place it keeps shadowing `SYS2.PROCLIB(UFSD)` — the server then starts from the wrong member, silently, with `SYSPRINT`/`SYSTERM` on `DUMMY` and dumps going somewhere other than the spool. Verify with `/S UFSD` that no `IEF196I` JCL echo appears.
 3. Deploy the new UFSD **and** every rebuilt consumer, then start.
 
@@ -150,7 +174,7 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 |---------|----------|-------------|
 | UFSD000I | I | UFSD starting — version + build commit (`-DIRTY` when built from a modified tree) |
 | UFSD001I | I | Ready — version + CSA/session/file summary |
-| UFSD002E | E | Predecessor SSCT found with ACTIVE anchor — refusing to start (run UFSDCLNP if orphaned) |
+| UFSD002E | E | Predecessor SSCT belongs to a running UFSD (`UFSD155W`) or to an anchor whose ASCB cannot be checked (`UFSD156W`) — refusing to start |
 | UFSD003E | E | Predecessor reclaim failed (supervisor state) — startup fails |
 | UFSD004I | I | Orphaned predecessor reclaimed at startup — CSA recovered |
 | UFSD005I | I | libc370 version + commit this module was linked against |
@@ -202,9 +226,9 @@ skipped; the rest of the member is still processed.
 | UFSD104W | W | Unrecognized statement (first 40 characters echoed) |
 | UFSD105W | W | ROOT statement missing — startup fails |
 
-### Reclaim and UFSDCLNP (140–149, 152–154)
+### Reclaim and UFSDCLNP (140–149, 152–157)
 
-Messages 143–148 and 152–154 come from the shared reclaim routine
+Messages 143–148 and 152–156 come from the shared reclaim routine
 (`RECLAIM:` prefix) and appear both during UFSD startup (over an orphaned
 predecessor) and under standalone UFSDCLNP.
 
@@ -223,5 +247,8 @@ predecessor) and under standalone UFSDCLNP.
 | UFSD152W | W | Reclaim: client(s) still in flight after the drain ceiling — assumed leaked, CSA freed anyway |
 | UFSD153W | W | Reclaim: anchor eye-catcher mismatch — anchor not freed |
 | UFSD154I | I | Reclaim: no anchor (ssctsuse=NULL) — nothing to free |
+| UFSD155W | W | Reclaim: the server's ASCB is an assigned address space — UFSD is running, nothing reclaimed (verify with `D A,L`) |
+| UFSD156W | W | Reclaim: anchor flagged ACTIVE but its ASCB cannot be checked — nothing reclaimed (UFSDCLNP passes `force` and reclaims) |
+| UFSD157W | W | UFSDCLNP: cleanup suppressed, stop UFSD first (RC 8; follows UFSD155W) |
 
 > **Note:** The message numbers listed here reflect the current codebase. Exact numbers may differ slightly — consult the source for authoritative message IDs.

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -560,16 +560,42 @@ void ufsd_shutdown(UFSD_STC *ufsd, int mode);
 /* ufsd#rcl.c (#49) -- orphaned predecessor reclaim, shared by UFSD
 ** startup and the standalone UFSDCLNP utility.
 **
-** Finds a registered UFSD_SSNAME SSCT and, unless its anchor is still
-** flagged ACTIVE (every shutdown path clears the flag before the STC
-** ends, so a set flag means a live server), quiesces and frees it:
-** null the SSVT entry, clear ANCHOR_ACTIVE, drain inflight with the
-** router module still present, then deregister and free all CSA.
-** `force` skips the ACTIVE check (UFSDCLNP emergency semantics).
+** Finds a registered UFSD_SSNAME SSCT and, unless it belongs to a UFSD
+** that is still running, quiesces and frees it: null the SSVT entry,
+** clear ANCHOR_ACTIVE, drain inflight with the router module still
+** present, then deregister and free all CSA.
+**
+** Still running is decided in two steps (#53).  Every shutdown path
+** clears ANCHOR_ACTIVE before the STC ends, so the flag being CLEAR is
+** proof of an orphan.  A SET flag is not proof of a live server -- an
+** instance killed before its ESTAE ran leaves it set too -- so the
+** anchor's server_ascb is looked up in the ASVT to tell the two apart:
+**
+**   ACTIVE clear                          reclaim
+**   ACTIVE + server_ascb assigned         UFSD_RECLAIM_ACTIVE
+**   ACTIVE + server_ascb not in the ASVT  reclaim (orphan after FORCE)
+**   ACTIVE + server_ascb is the caller's  reclaim (SQA handed us the
+**                                         predecessor's ASCB block)
+**   ACTIVE + no ASCB to look up           UFSD_RECLAIM_ACTIVE unless
+**                                         `force`
+**
+** `force` (UFSDCLNP) therefore skips only that last, undecidable case;
+** a running server is off limits to both callers.
 ** Caller must be APF authorized and not under RTM. */
+/* Liveness states behind that table.  ufsd_server_state() is exported
+** for TSTUFSRC (test/mvs/tstufsrc.c): the DEAD and UNKNOWN branches are
+** the half of the guard a host test cannot reach, and the operator
+** action that would produce them for real -- FORCE -- needs master
+** console authority. */
+#define UFSD_SRV_DEAD         0     /* ASCB belongs to no address space  */
+#define UFSD_SRV_LIVE         1     /* ASCB assigned -- server running   */
+#define UFSD_SRV_UNKNOWN      2     /* nothing to check the ASCB against */
+
+int ufsd_server_state(UFSD_ANCHOR *anchor)                           asm("UFSD@SRV");
+
 #define UFSD_RECLAIM_NONE     0     /* no UFSD SSCT registered           */
 #define UFSD_RECLAIM_DONE     1     /* orphaned predecessor reclaimed    */
-#define UFSD_RECLAIM_ACTIVE   2     /* predecessor looks live; untouched */
+#define UFSD_RECLAIM_ACTIVE   2     /* live (or undecidable); untouched  */
 #define UFSD_RECLAIM_FAIL   (-1)    /* cannot enter supervisor state     */
 
 int ufsd_reclaim(int force)                                          asm("UFSD@RCL");

--- a/include/ufsdasv.h
+++ b/include/ufsdasv.h
@@ -1,0 +1,46 @@
+/* UFSDASV.H - ASVT membership scan
+**
+** Deliberately free of MVS dependencies: this header and its
+** implementation (src/ufsd#asv.c) see the ASVT as nothing but an array
+** of 32-bit words, so the same source compiles for cc370 and for a host
+** compiler.  That is what makes the scan -- the one part of the #53
+** liveness guard that can silently break (off-by-one, high-bit skip) --
+** testable without an MVS round-trip (test/mvs/tstufsav.c,
+** `make test-host`).
+**
+** Everything that navigates real control blocks (CVT -> ASVT, anchor ->
+** server_ascb) stays in src/ufsd#rcl.c and is target-only.
+*/
+
+#ifndef UFSDASV_H
+#define UFSDASV_H
+
+/* ASVTAVAI/ASVTAVAL (ihaasvt.h): set in an entry means the ASID is
+** AVAILABLE, i.e. NOT assigned to an address space.  An available entry
+** carries the address of the next available entry alongside the bit, so
+** the bit -- not a zero test -- is what separates the two kinds. */
+#define UFSD_ASVT_AVAIL   0x80000000U
+
+/* ============================================================
+** ufsd_ascb_in_asvt
+**
+** Is `ascb` the ASCB of a currently assigned address space?
+**
+**   entries   &asvt->asvtenty[0] -- one word per ASID, ASID n at
+**             index n-1 (ihaasvt.h)
+**   nentries  asvt->asvtmaxu
+**   ascb      candidate ASCB address as a 32-bit value
+**
+** Returns 1 if an assigned entry holds exactly this address, else 0.
+**
+** Pointer identity only: nothing is read from *ascb, so a stale pointer
+** into reused SQA cannot mislead the caller through a field that is no
+** longer an ASCB's.  A `0` address, a null table or an empty table all
+** answer 0 -- callers must treat "not found" as "not proven live",
+** never as "proven dead", because address reuse can also produce a
+** false match (see src/ufsd#rcl.c).
+** ============================================================ */
+int ufsd_ascb_in_asvt(const unsigned *entries, unsigned nentries,
+                      unsigned ascb);
+
+#endif /* UFSDASV_H */

--- a/project.toml
+++ b/project.toml
@@ -36,7 +36,7 @@ sources = ["src/ufsd#ssi.c", "src/ufsd#buf.c"]
 [[module]]
 name = "UFSDCLNP"
 ac = 1
-sources = ["src/ufsdclnp.c", "src/ufsd#rcl.c"]
+sources = ["src/ufsdclnp.c", "src/ufsd#rcl.c", "src/ufsd#asv.c"]
 
 # UFSFMT — disk format utility (batch, unauthorized: plain BSAM/BDAM I/O)
 [[module]]
@@ -55,6 +55,19 @@ sources = ["client/libufstst.c", "client/libufs.c"]
 [[test]]
 name = "TSTUFSG"
 sources = ["test/mvs/tstufsg.c", "src/ufsfmtg.c"]
+
+# TSTUFSAV — the ASVT scan behind the #53 liveness guard. Portable C,
+# so it runs natively via `make test-host` as well as on the target.
+[[test]]
+name = "TSTUFSAV"
+sources = ["test/mvs/tstufsav.c", "src/ufsd#asv.c"]
+
+# TSTUFSRC — the same guard on real control blocks (CVT/ASVT/PSA), which
+# only the target has. Reads storage; registers nothing.
+[[test]]
+name = "TSTUFSRC"
+host = false          # MVS-only: needs a live ASVT
+sources = ["test/mvs/tstufsrc.c", "src/ufsd#rcl.c", "src/ufsd#asv.c"]
 
 # ── Library (consumed by HTTPD and others) ───────────────
 [lib]

--- a/src/ufsd#asv.c
+++ b/src/ufsd#asv.c
@@ -1,0 +1,36 @@
+/* UFSD#ASV.C - ASVT membership scan (issue #53)
+**
+** The arithmetic half of the reclaim liveness guard (see
+** src/ufsd#rcl.c).  Portable C: no MVS headers, no control block
+** navigation, no EBCDIC -- so `make test-host` can run it natively
+** (test/mvs/tstufsav.c).
+**
+** The scan compares ASVT entries against an ASCB address and reads
+** nothing out of the ASCB itself.  That is deliberate: the pointer it
+** validates comes from CSA and may be stale, and SQA storage of a
+** terminated address space can be reused.  Comparing addresses cannot
+** fault and needs no ASCB field offsets; reading a jobname out of a
+** reused block would answer with another address space's data.
+*/
+
+#include "ufsdasv.h"
+
+int
+ufsd_ascb_in_asvt(const unsigned *entries, unsigned nentries, unsigned ascb)
+{
+    unsigned i;
+
+    if (!entries || nentries == 0U || ascb == 0U)
+        return 0;
+
+    for (i = 0; i < nentries; i++) {
+        /* Available entry: no address space, and the word carries the
+        ** next available entry's address -- never an ASCB's. */
+        if (entries[i] & UFSD_ASVT_AVAIL)
+            continue;
+        if (entries[i] == ascb)
+            return 1;
+    }
+
+    return 0;
+}

--- a/src/ufsd#rcl.c
+++ b/src/ufsd#rcl.c
@@ -8,11 +8,29 @@
 **
 **   UFSD startup   main() reclaims BEFORE registering, so after /C a
 **                  plain /S UFSD suffices: no second SSCT chained, no
-**                  CSA leak.  force=0 -- a predecessor whose anchor is
-**                  still flagged ACTIVE is treated as a running server
-**                  and left untouched.
-**   UFSDCLNP       standalone emergency utility.  force=1 -- reclaims
-**                  unconditionally (its historical semantics).
+**                  CSA leak.  force=0.
+**   UFSDCLNP       standalone emergency utility.  force=1.
+**
+** Liveness (#53).  Neither caller may tear down a UFSD that is still
+** running.  UFSD_ANCHOR_ACTIVE alone cannot tell that apart: every path
+** out of a UFSD instance clears it, so a SET flag means either a live
+** server or one that died before even its ESTAE ran (FORCE).  The
+** anchor's server_ascb disambiguates -- ufsd_server_state() looks that
+** ASCB up in the ASVT:
+**
+**   ACTIVE clear                       both callers reclaim
+**   ACTIVE + ASCB assigned    LIVE     both callers refuse
+**   ACTIVE + ASCB not found   DEAD     both callers reclaim
+**   ACTIVE + ASCB is our own  DEAD     both callers reclaim
+**   ACTIVE + no ASCB to check UNKNOWN  force reclaims, startup refuses
+**
+** `force` therefore no longer skips the liveness check -- it skips only
+** the undecidable case.  A running server is off limits to UFSDCLNP as
+** well; stop it first.  Every error the scan can make lands on the safe
+** side: SQA address reuse can make a dead server look LIVE (cleanup is
+** refused, nothing is lost but convenience), while calling a live
+** server DEAD -- the one that frees CSA under live clients -- would
+** take an assigned ASVT entry that does not hold its own ASCB.
 **
 ** Quiescing (#39): null the SSVT entry and clear UFSD_ANCHOR_ACTIVE,
 ** then DRAIN anchor->inflight to zero -- keeping the eye catcher and
@@ -28,9 +46,12 @@
 */
 
 #include "ufsd.h"
+#include "ufsdasv.h"
 #include <string.h>
 #include <clibos.h>
 #include <clibwto.h>
+#include <cvt.h>
+#include <ihaasvt.h>
 
 /* Drain tuning -- see ufsd.c ufsd_drain().  The ceiling exceeds
 ** 2 * UFSD_WAIT_INTERVAL (2 * 5.00 s) so a client genuinely parked in the
@@ -68,6 +89,59 @@ ufsd_rcl_drain(UFSD_ANCHOR *anchor)
     return 0;
 }
 
+/* Is the address space that owns this anchor still there?  Problem
+** state: the CVT and the ASVT are fetch-accessible, and this runs
+** before the key-0 window the teardown needs (same as
+** ufsd_sess_cleanup(), ufsd#ses.c).
+**
+** server_ascb == NULL cannot happen for an anchor reached through a
+** registered SSCT -- startup stores the ASCB before ufsd_ssct_init() --
+** but it is reported UNKNOWN rather than DEAD anyway: "I could not
+** check" must never be answered with "go ahead and free the CSA".
+**
+** Our own ASCB is excluded first, and that exclusion is not a corner
+** case: an ASCB block returns to SQA at memterm, and the address space
+** created next -- typically the very restart that is reclaiming here --
+** can be handed the same block back.  Without the exclusion a FORCEd
+** predecessor would find its own recycled ASCB in the ASVT, call itself
+** live, and refuse both the start and the cleanup with no way out but
+** an IPL.  It cannot produce a false DEAD either: two address spaces
+** that are live at the same time never share one ASCB address, so a
+** genuinely running predecessor can never match the caller.
+**
+** Not static: the branches below are the half of the guard that no
+** host test can reach, so TSTUFSRC calls this directly on the target
+** with a hand-built anchor (test/mvs/tstufsrc.c). */
+int
+ufsd_server_state(UFSD_ANCHOR *anchor)
+{
+    CVT  *cvt;
+    ASVT *asvt;
+
+    if (!anchor->server_ascb)
+        return UFSD_SRV_UNKNOWN;
+
+    /* __ascb(0) is a PSAAOLD fetch (libc370 @@ascb.c) -- page 0, the
+    ** same page as the CVT pointer below, so no key-0 window. */
+    if (anchor->server_ascb == __ascb(0))
+        return UFSD_SRV_DEAD;             /* inherited, not inhabited */
+
+    cvt = *(CVT **)16;
+    if (!cvt)
+        return UFSD_SRV_UNKNOWN;
+
+    asvt = (ASVT *)cvt->cvtasvt;
+    if (!asvt || asvt->asvtmaxu == 0U)
+        return UFSD_SRV_UNKNOWN;
+
+    if (ufsd_ascb_in_asvt((const unsigned *)&asvt->asvtenty[0],
+                          asvt->asvtmaxu,
+                          (unsigned)anchor->server_ascb))
+        return UFSD_SRV_LIVE;
+
+    return UFSD_SRV_DEAD;
+}
+
 /* ============================================================
 ** ufsd_reclaim
 **
@@ -94,15 +168,32 @@ ufsd_reclaim(int force)
     anchor    = (UFSD_ANCHOR *)ssct->ssctsuse;
     anchor_ok = (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0);
 
-    /* Liveness gate.  Every path out of a UFSD instance -- clean /P,
-    ** drain-timeout retain, and the ESTAE -- clears UFSD_ANCHOR_ACTIVE
-    ** before the STC ends, so a set flag means a running server (or one
-    ** whose ESTAE never got to run, e.g. after FORCE).  Tearing that
-    ** down would yank the CSA from under live clients; without `force`,
-    ** hands off.  An SSCT without a valid anchor cannot be a live
-    ** server -- reclaim it. */
-    if (!force && anchor_ok && (anchor->flags & UFSD_ANCHOR_ACTIVE))
-        return UFSD_RECLAIM_ACTIVE;
+    /* Liveness gate (#53).  An SSCT whose anchor never carried the eye
+    ** catcher cannot be a live server -- reclaim it.  Otherwise the
+    ** ACTIVE flag opens the question and the ASCB answers it; see the
+    ** table in the file header.  A refusal states here what was found;
+    ** what follows from it ("not starting" / "cleanup suppressed") is
+    ** the caller's message. */
+    if (anchor_ok && (anchor->flags & UFSD_ANCHOR_ACTIVE)) {
+        switch (ufsd_server_state(anchor)) {
+        case UFSD_SRV_LIVE:
+            wtof("UFSD155W RECLAIM: UFSD IS ACTIVE IN ASCB %08X -- "
+                 "NOT RECLAIMED (VERIFY WITH D A,L)",
+                 (unsigned)anchor->server_ascb);
+            return UFSD_RECLAIM_ACTIVE;
+
+        case UFSD_SRV_UNKNOWN:
+            if (!force) {
+                wtof("UFSD156W RECLAIM: ANCHOR FLAGGED ACTIVE AND THE "
+                     "SERVER ASCB CANNOT BE CHECKED -- NOT RECLAIMED");
+                return UFSD_RECLAIM_ACTIVE;
+            }
+            break;                        /* force: reclaim anyway */
+
+        default:                          /* UFSD_SRV_DEAD */
+            break;                        /* orphan after FORCE    */
+        }
+    }
 
     /* --- Step 1: close the door and arm the parked-client bail ---
     ** Null the SSVT entry so no NEW iefssreq call dispatches into UFSDSSIR,

--- a/src/ufsd.c
+++ b/src/ufsd.c
@@ -359,8 +359,13 @@ main(int argc, char **argv)
     ** start over it. */
     rc = ufsd_reclaim(0);
     if (rc == UFSD_RECLAIM_ACTIVE) {
+        /* Since #53 startup reclaims an ACTIVE-flagged predecessor whose
+        ** address space is gone, so this is either a genuinely running
+        ** UFSD (UFSD155W named its ASCB) or an anchor whose ASCB could
+        ** not be checked at all (UFSD156W) -- the one case left for the
+        ** standalone utility. */
         wtof("UFSD002E UFSD ALREADY REGISTERED AND ACTIVE -- NOT "
-             "STARTING (IF ORPHANED, RUN UFSDCLNP)");
+             "STARTING (IF NOT RUNNING, RUN UFSDCLNP)");
         return 8;
     }
     if (rc == UFSD_RECLAIM_FAIL) {

--- a/src/ufsdclnp.c
+++ b/src/ufsdclnp.c
@@ -14,10 +14,14 @@
 ** (src/ufsd#rcl.c) and UFSD startup runs it itself, so after an abend
 ** a plain /S UFSD suffices.  UFSDCLNP stays the standalone fallback:
 ** emergencies, older load libraries, and the case startup refuses --
-** a predecessor still flagged ACTIVE (e.g. after FORCE, when the
-** ESTAE never ran).  UFSDCLNP reclaims UNCONDITIONALLY (force=1): it
-** does not distinguish a crashed server from a running one, so stop
-** UFSD first (TSK-124 tracks refusing while the STC is alive).
+** an anchor flagged ACTIVE whose server ASCB cannot be checked.
+**
+** It reclaims with force=1, which since #53 no longer means
+** "unconditionally": a UFSD whose address space is still in the ASVT
+** is off limits here too.  Any UFSD_RECLAIM_ACTIVE reaching this
+** program therefore means a PROVEN live server -- force already covers
+** the undecidable case -- so the refusal below can say so plainly.
+** There is no override: stop UFSD first (/P, or FORCE if it hangs).
 **
 ** Recovery cycle after UFSD abend:
 **   /S UFSD           (reclaims the orphan itself, then starts)
@@ -51,6 +55,12 @@ main(int argc, char **argv)
     if (rc == UFSD_RECLAIM_NONE) {
         wtof("UFSD142I UFSDCLNP: SUBSYSTEM %s NOT REGISTERED", UFSD_SSNAME);
         return 0;
+    }
+    if (rc == UFSD_RECLAIM_ACTIVE) {
+        /* UFSD155W named the address space.  Nothing was touched. */
+        wtof("UFSD157W UFSDCLNP: CLEANUP SUPPRESSED -- "
+             "STOP UFSD FIRST (/P UFSD)");
+        return 8;
     }
     if (rc != UFSD_RECLAIM_DONE)
         return 8;                         /* UFSD143E already issued */

--- a/test/mvs/tstufsav.c
+++ b/test/mvs/tstufsav.c
@@ -1,0 +1,163 @@
+/* TSTUFSAV.C - ASVT membership scan tests (issue #53)
+**
+** Covers the scan the reclaim liveness guard rests on
+** (src/ufsd#asv.c).  Dual-target: `make test-host` runs it natively,
+** `make test-mvs` runs it as a load module.
+**
+** The guard decides whether UFSDCLNP tears down the CSA of a running
+** UFSD or refuses.  Its dangerous direction is a false "not found":
+** that answers "the server is dead", and the caller then frees CSA out
+** from under live clients.  Two ways to produce one silently are an
+** off-by-one that stops before the last ASVT entry and a high-bit test
+** that skips assigned entries instead of available ones -- so both are
+** asserted from either side here.
+**
+** Addresses below are plausible MVS 3.8j SQA values (24-bit, ASCBs
+** live low in storage), but the scan is pure comparison, so nothing
+** depends on that.
+*/
+
+#include <mbtcheck.h>
+#include "ufsdasv.h"
+
+#define ASCB_A   0x00F01000U     /* the ASCB we are looking for       */
+#define ASCB_B   0x00F02000U     /* some other address space's ASCB   */
+#define ASCB_C   0x00F03000U
+
+/* An available entry: the AVAIL bit plus the address of the next
+** available entry (an address INSIDE the ASVT, never an ASCB's). */
+#define AVAIL(next)  (UFSD_ASVT_AVAIL | (unsigned)(next))
+
+/* ============================================================
+** check_position
+**
+** The same ASCB placed at every index of a table must be found at
+** every index.  First and last are the ones that break: an off-by-one
+** loop misses index nentries-1, a loop starting at 1 misses ASID 1
+** (MASTER, index 0).
+** ============================================================ */
+static void
+check_position(void)
+{
+    unsigned entries[8];
+    char     msg[64];
+    unsigned n;
+    unsigned i;
+
+    for (n = 0; n < 8U; n++) {
+        for (i = 0; i < 8U; i++)
+            entries[i] = ASCB_B;
+        entries[n] = ASCB_A;
+
+        sprintf(msg, "found at index %u of 8", n);
+        CHECK(ufsd_ascb_in_asvt(entries, 8U, ASCB_A), msg);
+    }
+}
+
+/* ============================================================
+** check_bounds
+**
+** nentries is asvtmaxu and is the whole contract with the caller: an
+** entry past it belongs to no address space and must not be read.  A
+** scan that over-runs by one would report a dead server as live
+** (harmless) -- or, on a table sized from a different field, walk into
+** storage that is not the ASVT at all.
+** ============================================================ */
+static void
+check_bounds(void)
+{
+    unsigned entries[4];
+
+    entries[0] = ASCB_B;
+    entries[1] = ASCB_C;
+    entries[2] = ASCB_B;
+    entries[3] = ASCB_A;                  /* only inside the 4th slot */
+
+    CHECK(ufsd_ascb_in_asvt(entries, 4U, ASCB_A),
+          "last entry is scanned");
+    CHECK(!ufsd_ascb_in_asvt(entries, 3U, ASCB_A),
+          "entry past nentries is not scanned");
+    CHECK(!ufsd_ascb_in_asvt(entries, 0U, ASCB_A),
+          "empty table finds nothing");
+    CHECK(!ufsd_ascb_in_asvt(NULL, 4U, ASCB_A),
+          "null table finds nothing");
+    CHECK(!ufsd_ascb_in_asvt(entries, 4U, 0U),
+          "a null ASCB is never found");
+}
+
+/* ============================================================
+** check_avail
+**
+** Available entries carry an address next to the AVAIL bit.  Masking
+** it off before the comparison -- or testing the bit the wrong way
+** round -- would match a free-chain word against an ASCB address and
+** call a dead server live, or skip every assigned entry and call a
+** live server dead.  Both are asserted.
+** ============================================================ */
+static void
+check_avail(void)
+{
+    unsigned entries[4];
+
+    /* The AVAIL bit sits on top of the very address we search for. */
+    entries[0] = ASCB_B;
+    entries[1] = AVAIL(ASCB_A);
+    entries[2] = AVAIL(0);                /* last available entry     */
+    entries[3] = ASCB_C;
+
+    CHECK(!ufsd_ascb_in_asvt(entries, 4U, ASCB_A),
+          "available entry is not a match, bit or no bit");
+
+    /* Same table, one assigned entry added: still found. */
+    entries[2] = ASCB_A;
+    CHECK(ufsd_ascb_in_asvt(entries, 4U, ASCB_A),
+          "assigned entry next to available ones is found");
+
+    /* Every entry available: nothing is assigned, nothing matches. */
+    entries[0] = AVAIL(ASCB_A);
+    entries[1] = AVAIL(ASCB_A);
+    entries[2] = AVAIL(ASCB_A);
+    entries[3] = AVAIL(ASCB_A);
+    CHECK(!ufsd_ascb_in_asvt(entries, 4U, ASCB_A),
+          "fully available table finds nothing");
+}
+
+/* ============================================================
+** check_table
+**
+** One table shaped like a small system: MASTER, JES2, a few started
+** tasks, holes where address spaces have ended.  UFSD's ASCB is in
+** it; the address one slot below it is not.
+** ============================================================ */
+static void
+check_table(void)
+{
+    unsigned entries[6];
+
+    entries[0] = 0x00F00000U;             /* ASID 1  MASTER           */
+    entries[1] = 0x00F00800U;             /* ASID 2  JES2             */
+    entries[2] = AVAIL(0x00000010U);      /* ASID 3  ended            */
+    entries[3] = ASCB_A;                  /* ASID 4  UFSD             */
+    entries[4] = ASCB_C;                  /* ASID 5  HTTPD            */
+    entries[5] = AVAIL(0);                /* ASID 6  never used       */
+
+    CHECK(ufsd_ascb_in_asvt(entries, 6U, ASCB_A),
+          "system table: UFSD ASCB found");
+    CHECK(!ufsd_ascb_in_asvt(entries, 6U, ASCB_A - 8U),
+          "system table: a near miss is not a match");
+    CHECK(!ufsd_ascb_in_asvt(entries, 6U, 0x00000010U),
+          "system table: a free chain address is not a match");
+}
+
+int
+main(void)
+{
+    printf("=== UFSD ASVT membership scan tests ===\n");
+
+    check_position();
+    check_bounds();
+    check_avail();
+    check_table();
+
+    return mbt_test_summary("TSTUFSAV");
+}

--- a/test/mvs/tstufsrc.c
+++ b/test/mvs/tstufsrc.c
@@ -1,0 +1,117 @@
+/* TSTUFSRC.C - Reclaim liveness guard, target side (issue #53)
+**
+** MVS-only companion to TSTUFSAV.  The host test covers the ASVT scan
+** as arithmetic (src/ufsd#asv.c); this one covers what only a real
+** system has: the CVT -> ASVT navigation, and the three answers
+** ufsd_server_state() (src/ufsd#rcl.c) gives about an anchor's
+** server_ascb.
+**
+** It exists because the operator action that produces the interesting
+** branch -- FORCE the STC, leaving UFSD_ANCHOR_ACTIVE set with the
+** address space gone -- needs master console authority, so it cannot
+** be driven from the mvsMF console the rest of the suite uses.  Feeding
+** the guard a hand-built anchor reaches the same code with the same
+** control blocks.
+**
+** The anchor here is a local struct, not CSA: the guard reads exactly
+** one field out of it and touches nothing else, so no GETMAIN, no
+** key-0, and nothing registered with the system.  A UFSD that happens
+** to be running is not affected in any way.
+*/
+
+#include <mbtcheck.h>
+#include <clibos.h>
+#include "ufsd.h"
+
+/* State names for the failure messages -- a bare 0/1/2 in a test log
+** costs a trip to the header. */
+static const char *
+state_name(int state)
+{
+    switch (state) {
+    case UFSD_SRV_DEAD:    return "DEAD";
+    case UFSD_SRV_LIVE:    return "LIVE";
+    case UFSD_SRV_UNKNOWN: return "UNKNOWN";
+    default:               return "?";
+    }
+}
+
+static void
+check_state(const char *what, void *server_ascb, int want)
+{
+    UFSD_ANCHOR anchor;
+    char        msg[96];
+    int         got;
+
+    anchor.server_ascb = server_ascb;
+    got = ufsd_server_state(&anchor);
+
+    sprintf(msg, "%s -> %s (got %s)", what, state_name(want),
+            state_name(got));
+    CHECK(got == want, msg);
+}
+
+int
+main(void)
+{
+    void *self;
+    void *master;
+
+    printf("=== UFSD reclaim liveness guard (target) ===\n");
+
+    self   = __ascb(0);                   /* this address space   */
+    master = __ascb(1);                   /* ASID 1 -- always up  */
+
+    printf("  ASCB: self=%08X master=%08X\n", (unsigned)self,
+           (unsigned)master);
+
+    /* Nothing to look up: never answer "dead", because the caller
+    ** would free the CSA on that answer. */
+    check_state("no ASCB recorded", NULL, UFSD_SRV_UNKNOWN);
+
+    /* A live address space that is not us: this is the answer that
+    ** stops UFSDCLNP tearing down a running server. */
+    CHECK(master != NULL, "MASTER ASCB located via __ascb(1)");
+    if (master)
+        check_state("MASTER ASCB", master, UFSD_SRV_LIVE);
+
+    /* Addresses no address space owns.  Inside MASTER's own ASCB and
+    ** in the PSA -- both are valid storage, so a scan that matched on
+    ** anything but an exact ASVT entry would call them live. */
+    if (master)
+        check_state("inside MASTER's ASCB", (char *)master + 8,
+                    UFSD_SRV_DEAD);
+    check_state("PSA address", (void *)0x100, UFSD_SRV_DEAD);
+
+    /* Our own ASCB.  A restart handed the predecessor's recycled ASCB
+    ** block sees exactly this, and must read it as an orphan's --
+    ** otherwise /S UFSD and UFSDCLNP both refuse and only an IPL is
+    ** left.  Note this is deliberately NOT the LIVE answer even though
+    ** the address IS in the ASVT. */
+    CHECK(self != NULL, "own ASCB located via __ascb(0)");
+    if (self)
+        check_state("own ASCB", self, UFSD_SRV_DEAD);
+
+    /* If UFSD is up while this runs, its anchor is the real thing --
+    ** worth asserting that the guard says LIVE about the server that
+    ** is serving us.  Skipped (not failed) when nothing is registered:
+    ** the suite must pass on a system without the STC. */
+    {
+        SSCT        *ssct   = ssct_find(UFSD_SSNAME);
+        UFSD_ANCHOR *anchor = ssct ? (UFSD_ANCHOR *)ssct->ssctsuse : NULL;
+
+        if (anchor && memcmp(anchor->eye, "UFSDANCR", 8) == 0
+            && anchor->server_ascb) {
+            printf("  live %s anchor at %08X, server ASCB %08X\n",
+                   UFSD_SSNAME, (unsigned)anchor,
+                   (unsigned)anchor->server_ascb);
+            CHECK(ufsd_server_state(anchor) == UFSD_SRV_LIVE,
+                  "registered UFSD anchor reads LIVE");
+        } else {
+            printf("  no registered %s anchor -- live case skipped\n",
+                   UFSD_SSNAME);
+        }
+    }
+
+    return mbt_test_summary("TSTUFSRC");
+}


### PR DESCRIPTION
Closes #53.

UFSDCLNP tore down SSCT, SSI router and CSA without ever asking whether UFSD was still running. Against a live server that nulls the SSVT entry and clears `ANCHOR_ACTIVE` out from under it — client failures, and a double cleanup at the next shutdown.

`ANCHOR_ACTIVE` alone cannot answer the question: every shutdown path clears it, including the ESTAE, so a set flag means "no shutdown ran" — which covers both a live server and one killed before its ESTAE. The anchor's `server_ascb` (recorded at startup for cross-AS POST) settles it, looked up in the ASVT:

| Anchor state | `/S UFSD` | `/S UFSDCLNP` (`force`) |
|---|---|---|
| ACTIVE clear | reclaims | reclaims |
| ACTIVE, ASCB assigned | refuses (`UFSD155W` + `UFSD002E`) | refuses (`UFSD155W` + `UFSD157W`, RC 8) |
| ACTIVE, ASCB in no ASVT entry | reclaims | reclaims |
| ACTIVE, ASCB is our own | reclaims | reclaims |
| ACTIVE, no ASCB to look up | refuses (`UFSD156W` + `UFSD002E`) | reclaims |

So `force` no longer means "unconditionally" — it covers only the last, undecidable row. A running server is off limits to UFSDCLNP as well, with no override. Startup gains the third row: a predecessor that is provably gone is now reclaimed instead of refused.

## Row four is the load-bearing one

An ASCB block returns to SQA at memterm and the next address space created can be handed the same block. Measured on mvsdev during verification:

```
UFSD155W ... UFSD IS ACTIVE IN ASCB 00FD40D0     <- server before the kill
C UFSD -> ESTAE -> address space gone
S UFSD -> UFSD004I ORPHANED PREDECESSOR RECLAIMED
UFSD155W ... UFSD IS ACTIVE IN ASCB 00FD40D0     <- same block after the restart
```

An STC restart getting its predecessor's ASCB back is the normal case here, not a corner case. Without excluding the caller's own ASCB, the guard would refuse **every** post-kill restart on this system — `/S UFSD` refuses, UFSDCLNP refuses, IPL — the same dead end #53 exists to close, with the sign flipped. The exclusion cannot hide a live server: two address spaces alive at once never share an ASCB address.

The scan compares addresses and reads nothing out of the ASCB, since a jobname read from a reused block would be another address space's. The residual error is the harmless one: an address reused by a *third* address space makes a dead server look alive and cleanup is refused (`D A,L` tells the operator which it is).

## Tests

Split the same way as the code:

- **TSTUFSAV** (host + MVS) — the ASVT scan as arithmetic (`src/ufsd#asv.c`, portable C). Covers its two silent failure modes: an off-by-one past the last ASID and an inverted available-bit test. Both were confirmed to fail the test when injected.
- **TSTUFSRC** (MVS only) — `ufsd_server_state()` on real CVT/ASVT/PSA with a hand-built anchor: `NULL` → UNKNOWN, MASTER's ASCB → LIVE, an address inside MASTER's ASCB and a PSA address → DEAD, our own ASCB → DEAD *while it sits in the ASVT*, and the registered UFSD anchor → LIVE. Reads storage only; registers nothing, so it is safe against a running STC.

The indirection in TSTUFSRC is necessary rather than convenient: MVS rejects `FORCE` for a cancelable address space (`IEE838I … CANCELABLE - ISSUE CANCEL BEFORE FORCE`), and a `CANCEL` always reaches the ESTAE, which clears the flag. The ACTIVE-flagged-orphan state cannot be produced on demand.

## MVS verification (mvsdev)

- UFSDCLNP against the running server: `UFSD155W` + `UFSD157W`, `IEF142I … COND CODE 0008`, nothing torn down
- server healthy afterwards: LIBUFTST full round trip (MKDIR, FOPEN/FWRITE, STAT, LS, FREAD/FGETS, REMOVE, RMDIR), CC 0
- start over an orphan: `UFSD004I ORPHANED PREDECESSOR RECLAIMED`, twice
- TSTUFSRC 8/8 in both the batch and the TSO step

**Not verified:** the full kill-and-restart cycle through `ufsd_reclaim`'s DEAD branch, for the FORCE reason above. Both halves are covered separately, and the branch falls through `default: break` into the teardown with no path around it.