### PR TITLE
Cross mount points when reading a directory (#52)

### DIFF
--- a/client/libufstst.c
+++ b/client/libufstst.c
@@ -69,6 +69,7 @@ main(int argc, char **argv)
     char      linebuf[64];
     UINT32    items;
     int       rc;
+    int       mp_fail = 0;   /* #52: listing vs stat mismatches */
 
     (void)argc;
 
@@ -164,6 +165,103 @@ main(int argc, char **argv)
     } else {
         wtof("LUFTSTRFE MKDIR /ROFS_TEST_DIR: rc=%d last_rc=%d (expected %d)",
              rc, ufs_last_rc(ufs), UFSD_RC_ROFS);
+    }
+
+    /* ============================================================
+    ** Step 1e: Listing and stat must agree on the same path (#52)
+    **
+    ** A directory entry and a stat of the very same path are two
+    ** views of one inode, so they have to name one owner, one group
+    ** and one inode number.  They did not at a mount point: DIRREAD
+    ** reported the mount point directory on the parent disk (owner
+    ** UFSD/SYS1, as mkdir_p wrote it) while STAT resolved the mount
+    ** and reported the mounted filesystem's root inode.
+    **
+    ** Every entry of "/" is checked, not a hardcoded mount path, so
+    ** the check follows whatever the running system has mounted --
+    ** and covers the plain directories at the same time, where the
+    ** two views must keep agreeing.
+    ** ============================================================ */
+    {
+        UFSDDESC *mdesc;
+        UFSDLIST *dl;
+        UFSDLIST  sb;
+        char      mpath[72];
+        unsigned  checked  = 0;
+        unsigned  root_ino = 0;
+
+        if (ufs_stat(ufs, "/", &sb) == 0)
+            root_ino = sb.inode_number;
+
+        mdesc = ufs_diropen(ufs, "/", NULL);
+        if (!mdesc) {
+            wtof("LUFTSTMPE diropen / failed");
+            mp_fail++;
+        } else {
+            while ((dl = ufs_dirread(mdesc)) != NULL) {
+                if (strcmp(dl->name, ".") == 0) continue;
+                if (strcmp(dl->name, "..") == 0) continue;
+                if (strlen(dl->name) > sizeof(mpath) - 2U) continue;
+
+                mpath[0] = '/';
+                strcpy(mpath + 1, dl->name);
+
+                rc = ufs_stat(ufs, mpath, &sb);
+                if (rc != 0) {
+                    wtof("LUFTSTMPE STAT %s failed RC=%d", mpath, rc);
+                    mp_fail++;
+                    continue;
+                }
+
+                checked++;
+
+                if (strcmp(dl->owner, sb.owner) != 0
+                    || strcmp(dl->group, sb.group) != 0
+                    || dl->inode_number != sb.inode_number) {
+                    wtof("LUFTSTMPE %s: LS %s/%s ino=%u BUT STAT %s/%s ino=%u",
+                         mpath, dl->owner, dl->group, dl->inode_number,
+                         sb.owner, sb.group, sb.inode_number);
+                    mp_fail++;
+                } else {
+                    wtof("LUFTSTMPI %s: LS = STAT (%s/%s, ino=%u)",
+                         mpath, sb.owner, sb.group, sb.inode_number);
+                }
+
+                /* ".." one level down must name "/" again, whether
+                ** the directory is a plain one or the root of a
+                ** mounted filesystem -- at a mounted root it is the
+                ** directory CONTAINING the mount point, which lives
+                ** on the parent disk. */
+                if (sb.attr[0] == 'd') {
+                    UFSDDESC *sub = ufs_diropen(ufs, mpath, NULL);
+                    UFSDLIST *se;
+                    int       seen = 0;
+
+                    if (!sub) {
+                        wtof("LUFTSTMPE diropen %s failed", mpath);
+                        mp_fail++;
+                    } else {
+                        while ((se = ufs_dirread(sub)) != NULL) {
+                            if (strcmp(se->name, "..") != 0) continue;
+                            seen = 1;
+                            if (se->inode_number != root_ino) {
+                                wtof("LUFTSTMPE %s/..: ino=%u, expected %u",
+                                     mpath, se->inode_number, root_ino);
+                                mp_fail++;
+                            }
+                        }
+                        ufs_dirclose(&sub);
+                        if (!seen) {
+                            wtof("LUFTSTMPE %s: no .. entry", mpath);
+                            mp_fail++;
+                        }
+                    }
+                }
+            }
+            ufs_dirclose(&mdesc);
+            wtof("LUFTSTMPI %u entrie(s) of / checked, %d mismatch(es)",
+                 checked, mp_fail);
+        }
     }
 
     /* ============================================================
@@ -341,5 +439,11 @@ rmdir_test:
 close_sess:
     ufsfree(&ufs);
     wtof("LUFTST15I Session closed");
-    return 0;
+
+    /* The mount view check (step 1e) is the one step whose verdict
+    ** reaches the runner: it compares two answers from the server
+    ** rather than reporting one, so a mismatch is a server defect and
+    ** nothing about the test environment can excuse it.  The older
+    ** steps keep reporting through WTO only. */
+    return mp_fail ? 8 : 0;
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,8 @@ UFSD enforces access control at three levels, applied in order:
 
 **Level 3 — RACF/RAKF per-file permissions.** Not implemented. There are no per-file or per-inode permission checks. The `mode` bits stored in inodes are informational only and not enforced by UFSD. Full RACF/RAKF integration with per-operation RACHECK is planned for a future release.
 
+`OWNER()` is the only owner UFSD enforces. The `owner`/`group` fields stored in the inodes — written by the format utility for the root directory, inherited from the parent directory for everything created afterwards — are metadata: they are reported by `stat` and by a directory listing, and no permission check reads them. The two are therefore free to differ, and a disk formatted for one userid can be mounted with `OWNER()` naming another; UFSD reports that with `UFSD125W` at mount time and honours `OWNER()`. To change who may write to a filesystem, change `OWNER()` — reformatting or rewriting inode owners has no effect on access.
+
 The check is applied in `do_fopen` (write mode), `do_mkdir`, `do_rmdir`, `do_remove`, and `do_fwrite` — six call sites (five functions; `do_fopen` calls the check twice), one helper function:
 
 ```c

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -211,6 +211,8 @@ All UFSD messages follow the `UFSDnnnX` pattern, where `nnn` is the message numb
 | UFSD076I | I | Inode cache refill complete |
 | UFSD122W | W | Cannot create mount point |
 | UFSD123W | W | Cannot mount dataset |
+| UFSD125W | W | The disk was formatted for one userid and mounted with `OWNER()` naming another. Both are kept: `OWNER()` decides who may write, the root inode owner is metadata that no permission check reads. Correct whichever is wrong — the parmlib statement, or the disk (reformat) |
+| UFSD126W | W | The mount point directory does not exist on the parent filesystem. The filesystem is mounted and reachable by path; only a listing of the parent directory keeps showing the mount point's own metadata instead of the mounted root's |
 
 ### Parmlib Parser (100–105)
 

--- a/docs/ufsdisk-spec.md
+++ b/docs/ufsdisk-spec.md
@@ -534,8 +534,12 @@ Starting from `datablock_start`, build the chain:
    - `owner = "HERC01"` (or from RACF ACEE)
    - `group = "ADMIN"` (or from RACF ACEE)
    - (UFSD note: directories that UFSD itself creates at runtime — e.g.
-     auto-created mount points via its internal `mkdir_p` — default to
-     `owner = "UFSD"`, `group = "SYS1"` rather than the `mkufs` values.)
+     auto-created mount points via its internal `mkdir_p` — inherit
+     `owner`/`group` from the directory they are created in, so a mount
+     point carries the same owner as the rest of the parent filesystem.
+     An empty owner is inherited as empty and means *unowned*; nothing
+     substitutes a value for it. Neither field is read by any permission
+     check — write access is decided by the mount's `OWNER()`.)
 4. Write root data block:
    - Entry 0: `inode=2, name="."`
    - Entry 1: `inode=2, name=".."` (root parent is itself)

--- a/include/ufsd.h
+++ b/include/ufsd.h
@@ -19,6 +19,7 @@
 #include <clibssvt.h>
 #include <time64.h>
 #include <clib64.h>
+#include "ufsdmnt.h"
 
 /* ============================================================
 ** UFSTIMEV — Dual-format on-disk timestamp (8 bytes)
@@ -225,6 +226,9 @@ struct ufsd_stc {
     /* AP-1d: open disk array (STC-local, not CSA) */
     UFSD_DISK      *disks[UFSD_MAX_DISKS];
     unsigned        ndisks;
+    /* #52: where each disk hangs in the tree, same indexing as
+    ** disks[].  Filled at mount time, read per directory entry. */
+    UFSD_MOUNTPT    mountpt[UFSD_MAX_DISKS];
 };
 
 /* ============================================================

--- a/include/ufsdmnt.h
+++ b/include/ufsdmnt.h
@@ -1,0 +1,113 @@
+/* UFSDMNT.H - Mount point table (issue #52)
+**
+** Where each mounted filesystem hangs in the tree, expressed as inode
+** numbers instead of paths.  do_dirread (src/ufsd#fil.c) consults this
+** once per directory entry to decide whether the entry it just read is
+** a mount point and its metadata therefore lives on another disk --
+** which is what makes `ls /u` and `ufs_stat /u/user` agree, the way
+** Unix `ls -l` crosses a mount.  A per-entry path reconstruction would
+** need a reverse ".." walk and a stack buffer for every entry; two
+** integer compares need neither.
+**
+** Deliberately free of MVS and UFSD dependencies: the table is nothing
+** but indices and inode numbers here, so the same source compiles for
+** cc370 and for a host compiler and the index arithmetic -- the part
+** that silently breaks when a filesystem is unmounted and the disk
+** array is compacted underneath it -- is testable without an MVS round
+** trip (test/mvs/tstufsmp.c, `make test-host`).
+**
+** Everything that reads a disk (inode lookup at mount time, crossing
+** into another disk's root inode) stays in src/ufsd#ini.c and
+** src/ufsd#fil.c and is target-only.
+*/
+
+#ifndef UFSDMNT_H
+#define UFSDMNT_H
+
+/* No parent: the root filesystem, and any entry whose parent has been
+** unmounted.  Never a valid index, so a table cleared to zero is not
+** silently "everything hangs off disk 0". */
+#define UFSD_MNT_NOPARENT  (-1)
+
+/* External names, as everywhere else in UFSD (see include/ufsd.h).
+** Not cosmetic here: cc370 derives an 8-character MVS name from the
+** first characters of the C name, so ufsd_mount_child and
+** ufsd_mount_remove would both become UFSD@MOU and the linker would
+** resolve calls to whichever it saw first.  The host build keeps the
+** C names -- nothing there is limited to 8 characters. */
+#ifdef __MVS__
+#define UFSD_MNT_EXTNAME(n)  asm(n)
+#else
+#define UFSD_MNT_EXTNAME(n)
+#endif
+
+/* ============================================================
+** UFSD_MOUNTPT
+**
+** One entry per disk, parallel to UFSD_STC.disks[] and indexed the
+** same way.  Filled when the disk is mounted, because the mount point
+** directory can only be looked up while its own parent is reachable,
+** and read once per directory entry afterwards.
+**
+**   pdisk  index of the disk holding the mount point directory
+**   ino    inode of the mount point directory itself, on pdisk
+**          (/u/user -- the directory the filesystem covers)
+**   pino   inode of the directory containing it, on pdisk
+**          (/u -- what ".." resolves to at the mounted root)
+**
+** ino and pino are on the SAME disk.  pino is what the mounted
+** filesystem's ".." must answer with: in Unix "/u/user/.." is "/u",
+** not the covered directory.
+** ============================================================ */
+typedef struct ufsd_mountpt UFSD_MOUNTPT;
+struct ufsd_mountpt {
+    int      pdisk;
+    unsigned ino;
+    unsigned pino;
+};
+
+/* ============================================================
+** ufsd_mount_child
+**
+** Which filesystem is mounted on directory `ino` of disk `pdisk`?
+**
+**   tab    &stc->mountpt[0]
+**   ntab   stc->ndisks
+**
+** Returns the disk index of the filesystem mounted there, or -1 when
+** the directory carries no mount.
+**
+** Both halves of the key are compared: inode numbers are per disk, so
+** inode 5 of the root disk and inode 5 of a mounted disk are different
+** directories, and matching on the inode alone would cross a mount
+** that is not there.  A zero inode is no directory at all (a free
+** directory slot) and never matches.
+** ============================================================ */
+int ufsd_mount_child(const UFSD_MOUNTPT *tab, unsigned ntab,
+                     int pdisk, unsigned ino)     UFSD_MNT_EXTNAME("UFSD@MNC");
+
+/* ============================================================
+** ufsd_mount_remove
+**
+** Keep the table valid across an UNMOUNT.  ufsd_disk_umount compacts
+** UFSD_STC.disks[] -- every disk above the removed one moves down a
+** slot -- so stored parent indices stop pointing at the disk they were
+** recorded for unless they move with it.
+**
+**   tab      &stc->mountpt[0]
+**   ntab     stc->ndisks BEFORE the removal
+**   removed  index being unmounted
+**
+** Entries above `removed` shift down; a parent index above `removed`
+** is decremented with it.  An entry whose parent WAS the removed disk
+** keeps its slot but loses its mount point: its directory went away
+** with the filesystem that held it, and a stale inode number there
+** would make do_dirread cross into it from whatever disk later takes
+** the index.  Such an entry is reset to UFSD_MNT_NOPARENT, which costs
+** nothing but the crossing -- the filesystem stays mounted and
+** reachable by path.
+** ============================================================ */
+void ufsd_mount_remove(UFSD_MOUNTPT *tab, unsigned ntab,
+                       unsigned removed)          UFSD_MNT_EXTNAME("UFSD@MNR");
+
+#endif /* UFSDMNT_H */

--- a/project.toml
+++ b/project.toml
@@ -62,6 +62,13 @@ sources = ["test/mvs/tstufsg.c", "src/ufsfmtg.c"]
 name = "TSTUFSAV"
 sources = ["test/mvs/tstufsav.c", "src/ufsd#asv.c"]
 
+# TSTUFSMP — the mount point table do_dirread crosses a mount with (#52).
+# Portable C, so it runs natively via `make test-host` as well as on the
+# target.
+[[test]]
+name = "TSTUFSMP"
+sources = ["test/mvs/tstufsmp.c", "src/ufsd#mnt.c"]
+
 # TSTUFSRC — the same guard on real control blocks (CVT/ASVT/PSA), which
 # only the target has. Reads storage; registers nothing.
 [[test]]

--- a/src/ufsd#fil.c
+++ b/src/ufsd#fil.c
@@ -1190,6 +1190,7 @@ do_dirread(UFSD_STC *stc, UFSD_ANCHOR *anchor, UFSD_SESSION *sess,
            UFSREQ *req, char *resp_data, unsigned *resp_data_len)
 {
     UFSD_DISK   *disk;
+    UFSD_DISK   *edisk;      /* disk holding the entry's inode */
     UFSD_GFILE  *gfile;
     UFSD_DINODE  dino;
     UFSD_DINODE  edino;
@@ -1248,33 +1249,48 @@ do_dirread(UFSD_STC *stc, UFSD_ANCHOR *anchor, UFSD_SESSION *sess,
 
             found_ino       = de->ino;
             gfile->position = entry_pos + 1U;
+            edisk           = disk;
 
-            /* Mount boundary: if this is ".." at the root of a
-            ** mounted filesystem, resolve the parent from the
-            ** mount point on the parent disk instead. */
-            if (de->name[0] == '.' && de->name[1] == '.'
-                && de->name[2] == '\0'
-                && gfile->ino == UFSD_ROOT_INO
-                && gfile->disk_idx > 0) {
-                UFSD_DISK *parent_disk = stc->disks[0];
-                if (parent_disk) {
-                    const char *mpath = disk->mountpath;
-                    unsigned    pino;
-                    char        pname[UFSD_NAME_MAX + 1];
-                    unsigned    ppino = 0;
-                    pino = ufsd_path_lookup(parent_disk, UFSD_ROOT_INO,
-                               mpath, &ppino, pname);
-                    if (ppino != 0) {
-                        found_ino = ppino;
-                        disk = parent_disk;
+            /* Mount boundaries.  The entry names a directory on this
+            ** disk, but its inode may not be on this disk: "." and
+            ** ".." at a mounted root belong to the parent filesystem,
+            ** and a mount point directory is covered by the root of
+            ** whatever is mounted on it.  Both are read from the disk
+            ** that actually holds the inode, so a listing agrees with
+            ** a stat of the same path (issue #52) -- as `ls -l` does
+            ** in Unix, which stats each entry and crosses mounts.
+            **
+            ** disk itself is not reassigned: it still owns the block
+            ** buffer this loop is walking. */
+            if (de->name[0] == '.' && de->name[1] == '\0') {
+                /* "." is this directory -- never a crossing. */
+            } else if (de->name[0] == '.' && de->name[1] == '.'
+                       && de->name[2] == '\0') {
+                if (gfile->ino == UFSD_ROOT_INO && gfile->disk_idx > 0) {
+                    UFSD_MOUNTPT *mp = &stc->mountpt[gfile->disk_idx];
+
+                    /* ".." at a mounted root is the directory
+                    ** CONTAINING the mount point (/u for /u/user),
+                    ** not the covered directory itself. */
+                    if (mp->pdisk >= 0 && mp->pino != 0U
+                        && stc->disks[mp->pdisk]) {
+                        found_ino = mp->pino;
+                        edisk     = stc->disks[mp->pdisk];
                     }
+                }
+            } else {
+                int child = ufsd_mount_child(stc->mountpt, stc->ndisks,
+                                             gfile->disk_idx, de->ino);
+                if (child >= 0 && stc->disks[child]) {
+                    found_ino = UFSD_ROOT_INO;
+                    edisk     = stc->disks[child];
                 }
             }
 
             memset(resp_data, 0, UFSD_DIRREAD_RLEN);
             *(unsigned *)resp_data = found_ino;
 
-            if (ufsd_ino_read(disk, found_ino, &edino) == UFSD_RC_OK) {
+            if (ufsd_ino_read(edisk, found_ino, &edino) == UFSD_RC_OK) {
                 mtime64_t mt;
 
                 *(unsigned *)(resp_data + 4)        = edino.filesize;

--- a/src/ufsd#ini.c
+++ b/src/ufsd#ini.c
@@ -42,6 +42,7 @@ static unsigned s_ddn_seq = 0;
 static UFSD_DISK *open_disk(const char *ddname);
 static void       close_disk(UFSD_DISK *disk);
 static int        mkdir_p(UFSD_DISK *disk, const char *path);
+static int        find_parent_disk(UFSD_STC *stc, const char *path);
 
 /* ============================================================
 ** s99_errmsg
@@ -274,6 +275,8 @@ mkdir_p(UFSD_DISK *disk, const char *path)
 {
     char         comp[128];
     char         partial[128];
+    char         pown[9];      /* parent dir owner, inherited */
+    char         pgrp[9];      /* parent dir group, inherited */
     const char  *p;
     const char  *end;
     unsigned     cur_ino;
@@ -315,20 +318,26 @@ mkdir_p(UFSD_DISK *disk, const char *path)
         /* Check if this component exists */
         found = ufsd_dir_lookup(disk, cur_ino, comp);
         if (found != 0) {
-            /* Fix up timestamps/owner if missing (legacy dirs) */
-            if (ufsd_ino_read(disk, found, &dino) == UFSD_RC_OK
-                && dino.owner[0] == '\0') {
-                mtime64_t now;
-                mtime64(&now);
-                dino.ctime.v2 = now;
-                dino.mtime.v2 = now;
-                dino.atime.v2 = now;
-                strcpy(dino.owner, "UFSD");
-                strcpy(dino.group, "SYS1");
-                ufsd_ino_write(disk, found, &dino);
-            }
+            /* Existing directory: left exactly as it is.  An earlier
+            ** version stamped UFSD/SYS1 and fresh timestamps onto any
+            ** directory whose owner field was empty, which made an
+            ** empty owner unrepresentable -- every startup wrote the
+            ** invented value straight back (issue #52).  An empty
+            ** owner is now a value in its own right: unowned. */
             cur_ino = found;
             continue;
+        }
+
+        /* Inherit owner/group from the parent directory.  A mount
+        ** point is an ordinary directory on the parent filesystem;
+        ** inventing an owner for it is what made `ls /u` and
+        ** `ufs_stat /u/user` name different owners (issue #52).
+        ** Read into dino, which the create path below overwrites. */
+        pown[0] = '\0';
+        pgrp[0] = '\0';
+        if (ufsd_ino_read(disk, cur_ino, &dino) == UFSD_RC_OK) {
+            memcpy(pown, dino.owner, sizeof(dino.owner));
+            memcpy(pgrp, dino.group, sizeof(dino.group));
         }
 
         /* Create the directory */
@@ -376,8 +385,8 @@ mkdir_p(UFSD_DISK *disk, const char *path)
             dino.mtime.v2 = now;
             dino.atime.v2 = now;
         }
-        strcpy(dino.owner, "UFSD");
-        strcpy(dino.group, "SYS1");
+        memcpy(dino.owner, pown, sizeof(dino.owner));
+        memcpy(dino.group, pgrp, sizeof(dino.group));
 
         if (ufsd_ino_write(disk, new_ino, &dino) != UFSD_RC_OK) {
             ufsd_sb_free_block(disk, new_blk);
@@ -480,6 +489,71 @@ ufsd_disk_mount_dyn(UFSD_STC *stc, const char *dsname,
 
     if (mode == UFSD_MOUNT_RO)
         disk->flags |= UFSD_DISK_RDONLY;
+
+    /* Record where this filesystem hangs in the tree (issue #52).
+    ** Resolved once, here, while the parent is still the longest
+    ** matching mount: do_dirread reads the table once per directory
+    ** entry and must not do path work there.  Done before the disk
+    ** joins disks[], or find_parent_disk would match it against its
+    ** own mount path and make it its own parent.
+    **
+    ** This write and the ndisks++ below are what keeps the table
+    ** valid: every slot below ndisks has been filled here, so nothing
+    ** ever reads the zero the STC was memset to -- which would read
+    ** as pdisk 0, the root disk, not as "no parent".  Anything added
+    ** between the two must not leave that gap. */
+    {
+        UFSD_MOUNTPT *mp = &stc->mountpt[stc->ndisks];
+
+        mp->pdisk = UFSD_MNT_NOPARENT;
+        mp->ino   = 0U;
+        mp->pino  = 0U;
+
+        if (strcmp(disk->mountpath, "/") != 0) {
+            int         pidx    = find_parent_disk(stc, disk->mountpath);
+            UFSD_DISK  *ppdisk  = stc->disks[pidx];
+            const char *rel     = disk->mountpath;
+            unsigned    mp_ino;
+            unsigned    mp_pino = 0U;
+            char        leaf[UFSD_NAME_MAX + 1];
+
+            /* Strip the parent's own mount prefix: a nested mount
+            ** point is looked up on the parent disk, whose root is
+            ** not "/". */
+            if (pidx > 0)
+                rel = disk->mountpath + strlen(ppdisk->mountpath);
+
+            mp_ino = rel[0]
+                   ? ufsd_path_lookup(ppdisk, UFSD_ROOT_INO, rel,
+                                      &mp_pino, leaf)
+                   : 0U;
+
+            if (mp_ino != 0U) {
+                mp->pdisk = pidx;
+                mp->ino   = mp_ino;
+                mp->pino  = mp_pino;
+            } else {
+                /* Reachable by path either way -- only the metadata
+                ** crossing in do_dirread is lost. */
+                wtof("UFSD126W MOUNT POINT %s NOT FOUND ON PARENT DISK",
+                     disk->mountpath);
+            }
+        }
+    }
+
+    /* The disk was formatted for one userid and mounted for another.
+    ** Both stay as they are: OWNER() decides who may write, the inode
+    ** owner is metadata, and only the operator can say which of the
+    ** two is the mistake (issue #52). */
+    if (disk->mount_owner[0]) {
+        UFSD_DINODE rdino;
+
+        if (ufsd_ino_read(disk, UFSD_ROOT_INO, &rdino) == UFSD_RC_OK
+            && rdino.owner[0]
+            && strncmp(rdino.owner, disk->mount_owner, 8) != 0)
+            wtof("UFSD125W %s ROOT OWNER=%.8s, MOUNTED OWNER=%.8s",
+                 disk->dsn, rdino.owner, disk->mount_owner);
+    }
 
     stc->disks[stc->ndisks++] = disk;
 
@@ -744,7 +818,11 @@ ufsd_disk_umount(UFSD_STC *stc, const char *mountpath)
     if (memcmp(ddname, "UFD", 3) == 0)
         __dsfree(ddname);
 
-    /* Compact the array */
+    /* Compact the array.  The mount point table is indexed the same
+    ** way, so it has to move with it (issue #52) -- and before
+    ** ndisks drops, which is the table's own bound. */
+    ufsd_mount_remove(stc->mountpt, stc->ndisks, (unsigned)found);
+
     for (i = (unsigned)found; i < stc->ndisks - 1U; i++)
         stc->disks[i] = stc->disks[i + 1U];
     stc->disks[--stc->ndisks] = NULL;

--- a/src/ufsd#mnt.c
+++ b/src/ufsd#mnt.c
@@ -1,0 +1,60 @@
+/* UFSD#MNT.C - Mount point table (issue #52)
+**
+** The index arithmetic behind the mount crossing in do_dirread.
+** Portable C: no MVS headers, no disk I/O, no EBCDIC -- see
+** include/ufsdmnt.h for why, and test/mvs/tstufsmp.c for the tests
+** `make test-host` runs on it natively.
+*/
+
+#include "ufsdmnt.h"
+
+int
+ufsd_mount_child(const UFSD_MOUNTPT *tab, unsigned ntab,
+                 int pdisk, unsigned ino)
+{
+    unsigned i;
+
+    if (!tab || ntab == 0U || ino == 0U || pdisk < 0)
+        return -1;
+
+    for (i = 0; i < ntab; i++) {
+        /* pdisk is compared first: an entry with no parent carries
+        ** ino 0 as well, but only the pair proves a mount point. */
+        if (tab[i].pdisk == pdisk && tab[i].ino == ino)
+            return (int)i;
+    }
+
+    return -1;
+}
+
+void
+ufsd_mount_remove(UFSD_MOUNTPT *tab, unsigned ntab, unsigned removed)
+{
+    unsigned i;
+
+    if (!tab || removed >= ntab) return;
+
+    /* Correct the parent indices while the array is still in the old
+    ** numbering -- afterwards there is no way to tell which disk an
+    ** index used to name. */
+    for (i = 0; i < ntab; i++) {
+        if (i == removed) continue;
+
+        if (tab[i].pdisk == (int)removed) {
+            /* Parent unmounted: the mount point directory went with
+            ** it (see include/ufsdmnt.h). */
+            tab[i].pdisk = UFSD_MNT_NOPARENT;
+            tab[i].ino   = 0U;
+            tab[i].pino  = 0U;
+        } else if (tab[i].pdisk > (int)removed) {
+            tab[i].pdisk--;
+        }
+    }
+
+    for (i = removed; i + 1U < ntab; i++)
+        tab[i] = tab[i + 1U];
+
+    tab[ntab - 1U].pdisk = UFSD_MNT_NOPARENT;
+    tab[ntab - 1U].ino   = 0U;
+    tab[ntab - 1U].pino  = 0U;
+}

--- a/test/mvs/tstufsmp.c
+++ b/test/mvs/tstufsmp.c
@@ -1,0 +1,223 @@
+/* TSTUFSMP.C - Mount point table tests (issue #52)
+**
+** Covers the table do_dirread crosses a mount with (src/ufsd#mnt.c).
+** Dual-target: `make test-host` runs it natively, `make test-mvs` runs
+** it as a load module.
+**
+** Two failure modes here are silent on a running system and both send
+** a client to the wrong disk:
+**
+**   - matching a directory entry on its inode number alone.  Inode
+**     numbers are per filesystem, so inode 5 exists on nearly every
+**     disk; a lookup that ignores the parent would report a mount on
+**     the first disk that happens to reuse the number, and the listing
+**     would show another filesystem's root where a plain directory is.
+**
+**   - not moving the parent indices when UNMOUNT compacts
+**     UFSD_STC.disks[].  Every disk above the removed one shifts down
+**     a slot, so a parent index recorded before the unmount then names
+**     a different filesystem -- the one that moved into that slot.
+**
+** So both are asserted from either side: a mount that must be found,
+** and a near miss on the same inode number that must not.
+**
+** The layout below is the sample parmlib (samplib/ufsdprm0) as a
+** table: a root disk, /tmp and /u/ibmuser on it, and one filesystem
+** nested inside another.  Inode numbers are arbitrary but reused
+** across disks on purpose -- that reuse is the point.
+*/
+
+#include <mbtcheck.h>
+#include "ufsdmnt.h"
+
+/* Disk indices, in mount order (parents before children, as
+** ufsd_ufs_init sorts them). */
+#define D_ROOT   0      /* /              */
+#define D_TMP    1      /* /tmp           */
+#define D_HOME   2      /* /u/ibmuser     */
+#define D_WORK   3      /* /tmp/work      */
+
+#define NDISKS   4U
+
+/* Root disk inodes: /u is 7, the mount point directories are 5 and 9. */
+#define INO_U        7U
+#define INO_TMP      5U
+#define INO_IBMUSER  9U
+
+/* /tmp's own inodes.  Its mount point directory for /tmp/work carries
+** inode 5 as well -- the same number as /tmp itself on the root disk,
+** on a different filesystem. */
+#define INO_WORK     5U
+#define INO_ROOT     2U
+
+/* ============================================================
+** sample_table
+**
+** Fill `tab` with the four-disk layout described above.
+** ============================================================ */
+static void
+sample_table(UFSD_MOUNTPT *tab)
+{
+    tab[D_ROOT].pdisk = UFSD_MNT_NOPARENT;   /* nothing covers "/"   */
+    tab[D_ROOT].ino   = 0U;
+    tab[D_ROOT].pino  = 0U;
+
+    tab[D_TMP].pdisk  = D_ROOT;              /* /tmp on the root     */
+    tab[D_TMP].ino    = INO_TMP;
+    tab[D_TMP].pino   = INO_ROOT;
+
+    tab[D_HOME].pdisk = D_ROOT;              /* /u/ibmuser, ".." = /u */
+    tab[D_HOME].ino   = INO_IBMUSER;
+    tab[D_HOME].pino  = INO_U;
+
+    tab[D_WORK].pdisk = D_TMP;               /* /tmp/work, nested    */
+    tab[D_WORK].ino   = INO_WORK;
+    tab[D_WORK].pino  = INO_ROOT;
+}
+
+/* ============================================================
+** check_lookup
+**
+** Every mount point is found from the disk that holds it, and only
+** from that disk.
+** ============================================================ */
+static void
+check_lookup(void)
+{
+    UFSD_MOUNTPT tab[NDISKS];
+
+    sample_table(tab);
+
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_ROOT, INO_TMP), D_TMP,
+             "/tmp is found on the root disk");
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_ROOT, INO_IBMUSER), D_HOME,
+             "/u/ibmuser is found on the root disk");
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_TMP, INO_WORK), D_WORK,
+             "a nested mount is found on its own parent disk");
+
+    /* INO_TMP and INO_WORK are the same number on two disks. */
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_HOME, INO_TMP), -1,
+             "the same inode number on another disk is not a mount");
+
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_ROOT, INO_U), -1,
+             "a plain directory carries no mount");
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_ROOT, 0U), -1,
+             "a free directory slot is never a mount");
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, UFSD_MNT_NOPARENT, INO_TMP), -1,
+             "no parent disk finds nothing");
+    CHECK_EQ(ufsd_mount_child(NULL, NDISKS, D_ROOT, INO_TMP), -1,
+             "null table finds nothing");
+    CHECK_EQ(ufsd_mount_child(tab, 0U, D_ROOT, INO_TMP), -1,
+             "empty table finds nothing");
+
+    /* ndisks is the whole contract with the caller: a slot past it
+    ** belongs to no mounted filesystem. */
+    CHECK_EQ(ufsd_mount_child(tab, (unsigned)D_WORK, D_TMP, INO_WORK), -1,
+             "an entry past ntab is not searched");
+}
+
+/* ============================================================
+** check_remove_reindex
+**
+** Unmount /tmp, which sits below /u/ibmuser in the array.  Everything
+** above it moves down one slot, and /u/ibmuser must still be found --
+** at its new index.
+** ============================================================ */
+static void
+check_remove_reindex(void)
+{
+    UFSD_MOUNTPT tab[NDISKS];
+
+    sample_table(tab);
+
+    /* Re-hang the nested mount under /u/ibmuser (disk 2) so the
+    ** removal has a parent index above it to correct. */
+    tab[D_WORK].pdisk = D_HOME;
+
+    ufsd_mount_remove(tab, NDISKS, (unsigned)D_TMP);
+
+    /* /u/ibmuser: was 2, now 1. */
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, D_ROOT, INO_IBMUSER), 1,
+             "a mount above the removed one is found at its new index");
+
+    /* The nested filesystem: was 3 under parent 2, now 2 under 1. */
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, 1, INO_WORK), 2,
+             "a parent index above the removed one moves with it");
+
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, D_ROOT, INO_TMP), -1,
+             "the unmounted filesystem is gone from the table");
+
+    CHECK_EQ(tab[NDISKS - 1U].pdisk, UFSD_MNT_NOPARENT,
+             "the vacated slot carries no stale parent");
+}
+
+/* ============================================================
+** check_remove_orphan
+**
+** Unmount /tmp while /tmp/work is mounted inside it.  The mount point
+** directory went away with the filesystem that held it, so the nested
+** entry must lose it -- keeping the inode number would cross into
+** /tmp/work from whichever filesystem later occupies that index.
+** ============================================================ */
+static void
+check_remove_orphan(void)
+{
+    UFSD_MOUNTPT tab[NDISKS];
+    int          i;
+    int          found;
+
+    sample_table(tab);
+    ufsd_mount_remove(tab, NDISKS, (unsigned)D_TMP);
+
+    found = 0;
+    for (i = 0; i < (int)(NDISKS - 1U); i++) {
+        if (ufsd_mount_child(tab, NDISKS - 1U, i, INO_WORK) >= 0)
+            found = 1;
+    }
+    CHECK(!found,
+          "a mount whose parent was unmounted is reachable from no disk");
+
+    /* The other mount on the removed disk's former parent is untouched. */
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, D_ROOT, INO_IBMUSER), 1,
+             "an unrelated mount survives the removal");
+}
+
+/* ============================================================
+** check_remove_bounds
+**
+** The last entry, and an index that names no disk at all.
+** ============================================================ */
+static void
+check_remove_bounds(void)
+{
+    UFSD_MOUNTPT tab[NDISKS];
+
+    sample_table(tab);
+    ufsd_mount_remove(tab, NDISKS, (unsigned)D_WORK);
+
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, D_ROOT, INO_TMP), D_TMP,
+             "removing the last entry leaves the others in place");
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS - 1U, D_TMP, INO_WORK), -1,
+             "the removed last entry is gone");
+
+    sample_table(tab);
+    ufsd_mount_remove(tab, NDISKS, NDISKS);
+    CHECK_EQ(ufsd_mount_child(tab, NDISKS, D_TMP, INO_WORK), D_WORK,
+             "an out-of-range removal changes nothing");
+
+    ufsd_mount_remove(NULL, NDISKS, (unsigned)D_TMP);
+    CHECK(1, "a null table does not fault");
+}
+
+int
+main(void)
+{
+    printf("=== UFSD mount point table tests ===\n");
+
+    check_lookup();
+    check_remove_reindex();
+    check_remove_orphan();
+    check_remove_bounds();
+
+    return mbt_test_summary("TSTUFSMP");
+}


### PR DESCRIPTION
Implements the decision recorded in #52: mount `OWNER(...)` is the sole authority for
write access, the inode owner is display metadata, and the two views of a mount point
are made to agree instead of disagreeing by design.

Closes #52. The one step the issue's Interim section still lists — switching the format
tools' default owner/group to empty — spans UFSFMT and ufsd-utils together and is tracked
separately (see *Follow-up* below).

## What changes

**`do_dirread` crosses mount points.** An entry's inode is read from the disk that
actually holds it: the root of the mounted filesystem for a mount point directory, the
parent filesystem for `..` at a mounted root. That is what `ls -l` does in Unix, and it
makes a listing agree with a stat of the same path.

Which disk that is comes from a new mount point table (`UFSD_MOUNTPT`, one entry per
disk, parallel to `stc->disks[]`), resolved once at mount time: two integer compares per
directory entry instead of reconstructing a path and looking it up per entry. `UNMOUNT`
compacts the disk array, so the table is compacted with it and parent indices move along.

This also fixes `..` for nested mounts — the old branch hardcoded `stc->disks[0]` as the
parent filesystem while `find_parent_disk` already supported deeper nesting.

**`mkdir_p` inherits owner/group from the parent directory** instead of inventing
`UFSD`/`SYS1` for a mount point directory. Its legacy fixup goes with it: it stamped
`UFSD`/`SYS1` onto any directory with an empty owner, which made an empty owner
unrepresentable — every startup wrote the invented value straight back. An empty owner
is now a value in its own right: unowned.

**Mount-time divergence is reported, not resolved.** A disk formatted for one userid and
mounted with `OWNER()` naming another gets `UFSD125W`; both values are kept. Only the
operator can say which of the two is the mistake. `UFSD126W` covers a mount point
directory missing from the parent filesystem — the filesystem is still mounted and
reachable by path, only the metadata crossing is lost.

## Red/green

**Host — `TSTUFSMP` (new, `make test-host`).** Covers the table's index arithmetic: the
inode-number collision across disks (inode 5 exists on nearly every filesystem, so
matching on the inode alone would cross a mount that is not there) and the reindexing an
`UNMOUNT` forces. 9 assertions red against a stub implementation, 20/20 green after.
Whole host suite: 170 PASS / 0 FAIL.

**MVS — `LIBUFTST` (extended).** New step compares the listing against a stat for every
entry of `/` — owner, group and inode number — and returns RC 8 on a mismatch, so the
verdict reaches the runner rather than a WTO line.

Red, against `AF0C611` (unmodified `main`) running on mvsdev:

```
LUFTSTMPE /tmp:     LS UFSD/SYS1 ino=61 BUT STAT ufsd/ufsd   ino=2
LUFTSTMPE /wwwroot: LS UFSD/SYS1 ino=62 BUT STAT httpd/httpd ino=2
LUFTSTMPI /TMP:     LS = STAT (UFSD/SYS1, ino=63)
LUFTSTMPI 4 entrie(s) of / checked, 2 mismatch(es)     -> CC 8
```

Green, with this change deployed:

```
LUFTSTMPI /tmp:     LS = STAT (ufsd/ufsd, ino=2)
LUFTSTMPI /wwwroot: LS = STAT (httpd/httpd, ino=2)
LUFTSTMPI 4 entrie(s) of / checked, 0 mismatch(es)     -> CC 0
```

The plain directories `/TMP` and `/WWWROOT` (legacy, owned `UFSD`/`SYS1`) agree in both
runs — the check is not simply "everything now matches".

## Not covered by a run

Two hunks are covered by inspection only, and mvsdev's topology is why:

- **`mkdir_p` inheritance.** `/tmp` and `/wwwroot` already exist there, so the create
  path never ran; the dynamic `MOUNT DSN=…` command does not call `mkdir_p` at all.
- **`..` at a mounted root.** Both mounts sit directly on `/`, so the expected parent
  inode is 2 — the same value a wrong answer (the mounted disk's own root) would give.
  The check only discriminates for a mount at depth ≥ 2 (`/u/user`, where `..` must be
  `/u`'s inode). Exercising either needs a parmlib mount at depth 2 on a freshly
  formatted dataset.

## Follow-up

`UFSFMT` (`src/ufsfmt.c:295`) and ufsd-utils (`pkg/ufs/image.go:40`) still default to
`HERC01`/`ADMIN`. This change makes an empty owner *representable* — nothing overwrites
it any more — but it does not make it the default. That switch has to happen in both
places at once or it breaks the byte-for-byte equivalence #50 established, so it is its
own change rather than part of this one.

Pre-existing and untouched: `gfile->disk_idx` in the global file table is not remapped
when `UNMOUNT` compacts `stc->disks[]`, so a directory handle held across an unmount can
name the wrong disk. Independent of this change.
