### PR TITLE
UFSFMT: leave the root directory unowned by default (#62)

### DIFF
--- a/docs/disk-setup.md
+++ b/docs/disk-setup.md
@@ -56,8 +56,8 @@ Statements are read from `SYSIN`. `PARM=` is not supported — there is one sour
 | `BLKSIZE` | 512–8192, multiple of 512 | `4096` | Block size |
 | `DDNAME` | DD name | `DISKFILE` | DD of the dataset to format |
 | `INODES` | 1.0–50.0 | `10.0` | Percent of blocks for inodes |
-| `OWNER` | 1–8 chars | `HERC01` | Root directory owner |
-| `GROUP` | 1–8 chars | `ADMIN` | Root directory group |
+| `OWNER` | 1–8 chars | *(none)* | Root directory owner |
+| `GROUP` | 1–8 chars | *(none)* | Root directory group |
 | `FORCE` | — | off | Overwrite an existing UFS filesystem |
 | `QUIET` | — | off | Suppress messages and the report |
 | `VERBOSE` | — | off | Extra per-phase messages |
@@ -124,6 +124,10 @@ UFSFMT91I   MOUNT    DSN(MIKEG1.UFSHOME) PATH(/your/mount/point) MODE(RW) OWNER(
 
 The `MOUNT` line carries the owner the disk was formatted for; formatting with the userid the disk will be mounted for is the documented convention.
 
+Without `OWNER` and `GROUP` the root directory is left unowned, the summary reads `(none)/(none)`, and the suggested `MOUNT` line comes without an `OWNER()` keyword — `OWNER()` with nothing in it is a syntax error to the parmlib parser, and a mount without `OWNER` is what an unowned filesystem means: any authenticated user may write to it.
+
+Those fields are metadata either way. Who may write to a mounted filesystem is decided by `OWNER()` on the `MOUNT` statement and by nothing else — see [Access Control](configuration.md#access-control).
+
 Return codes: **0** formatted, **4** `HELP` was requested (nothing was written), **8** the format did not complete. Messages and warnings go to `SYSTERM`, the report to `SYSPRINT`; `QUIET` suppresses the report but never an error.
 
 ---
@@ -179,8 +183,8 @@ Options:
 | `--size` | `10M` | Image size (e.g. `1M`, `500K`, `50M`) |
 | `--blksize` | 4096 | Block size (512, 1024, 2048, 4096, 8192) |
 | `--inodes` | 10% | Percentage of blocks reserved for inodes |
-| `--owner` | `$USER` → `HERC01` | Root directory owner (RACF userid); uppercased `$USER`, or `HERC01` if unset |
-| `--group` | `ADMIN` | Root directory group |
+| `--owner` | *(none)* | Root directory owner (RACF userid) |
+| `--group` | *(none)* | Root directory group |
 
 ## Step 2: Populate Content
 

--- a/docs/disk-setup.md
+++ b/docs/disk-setup.md
@@ -108,7 +108,7 @@ UFSFMT10I UFSFMT 1.1.0 -- UFS370 disk format utility
 UFSFMT26I Initialized 256 blocks (1.00 MB)
 UFSFMT51I Formatted 2 index blocks, 64 inode slots
 UFSFMT52I Formatted 252 data blocks
-UFSFMT71I Root directory created, owner=HERC01, group=ADMIN, mode=0755
+UFSFMT71I Root directory created, owner=HERC01, group=(none), mode=0755
 
 UFSFMT80I Format summary
 UFSFMT81I   Dataset . . . . . MIKEG1.UFSHOME
@@ -116,7 +116,7 @@ UFSFMT82I   Block size  . . . 4096
 UFSFMT83I   Total blocks  . . 256           (1.00 MB)
 UFSFMT84I   Inode blocks  . . 2             (64 slots, 62 free)
 UFSFMT85I   Data blocks . . . 252           (251 free)
-UFSFMT86I   Root owner  . . . HERC01/ADMIN
+UFSFMT86I   Root owner  . . . HERC01/(none)
 
 UFSFMT90I Add to your UFSD parmlib member:
 UFSFMT91I   MOUNT    DSN(MIKEG1.UFSHOME) PATH(/your/mount/point) MODE(RW) OWNER(HERC01)
@@ -160,7 +160,7 @@ Creating root.img (1M, blksize=4096, inodes=10.0%)
   Block size:      4096 bytes
   Inode blocks:    2 (64 inodes)
   Data blocks:     252 (free: 251)
-  Root owner:      MIKE/ADMIN
+  Root owner:      (none)/(none)
   Format:          UFS370 v1 (time64 timestamps)
 
   Upload to MVS:  ufsd-utils upload root.img --dsn YOUR.DATASET.NAME

--- a/docs/ufsdisk-spec.md
+++ b/docs/ufsdisk-spec.md
@@ -531,8 +531,9 @@ Starting from `datablock_start`, build the chain:
    - `filesize = 128` (2 × 64-byte entries)
    - `addr[0] = allocated_block`
    - `ctime/mtime/atime = now` (time64 format)
-   - `owner = "HERC01"` (or from RACF ACEE)
-   - `group = "ADMIN"` (or from RACF ACEE)
+   - `owner` = the owner given to the formatter, all-NUL when none was
+     given (which means *unowned*)
+   - `group` = likewise, all-NUL when none was given
    - (UFSD note: directories that UFSD itself creates at runtime — e.g.
      auto-created mount points via its internal `mkdir_p` — inherit
      `owner`/`group` from the directory they are created in, so a mount

--- a/include/ufsfmt.h
+++ b/include/ufsfmt.h
@@ -87,4 +87,35 @@ struct ufsfmt_geom {
 int ufsfmt_geometry(UFSFMT_GEOM *g, unsigned total_blocks,
                     unsigned blksize, double inode_pct);
 
+/* ============================================================
+** Reporting an owner that may be absent (#62)
+**
+** UFSFMT leaves owner and group empty unless OWNER/GROUP say
+** otherwise, so both the summary and the suggested parmlib line have
+** to render "no owner" as something other than nothing.  Both are
+** plain string work over ASCII-safe character literals, which is why
+** they sit here with the geometry and not in the target-only half.
+** ============================================================ */
+
+/* What the report prints where an owner would be. */
+#define UFSFMT_UNOWNED  "(none)"
+
+/* Returns owner, or UFSFMT_UNOWNED when it is empty or NULL. */
+const char *ufsfmt_owner_text(const char *owner);
+
+/* ============================================================
+** ufsfmt_mount_stmt
+**
+** Build the parmlib MOUNT statement the report suggests, into out
+** (at most outsz bytes including the NUL, always terminated).
+**
+** The OWNER keyword is omitted entirely when there is no owner:
+** `OWNER()` is a syntax error to the parmlib parser, and an operator
+** copying the suggested line has no reason to doubt it.  A mount
+** without OWNER is also what an unowned filesystem means -- any
+** authenticated user may write to it.
+** ============================================================ */
+void ufsfmt_mount_stmt(char *out, unsigned outsz,
+                       const char *dsn, const char *owner);
+
 #endif /* UFSFMT_H */

--- a/samplib/ufsfmt
+++ b/samplib/ufsfmt
@@ -60,8 +60,13 @@
 //* unless FORCE is given.
 //*
 //* SYSIN is optional -- omit it or use DUMMY to take every default
-//* (BLKSIZE 4096, INODES 10.0, OWNER HERC01, GROUP ADMIN).  The
-//* report always shows the values actually used.
+//* (BLKSIZE 4096, INODES 10.0, no OWNER, no GROUP).  The report
+//* always shows the values actually used.
+//*
+//* Without OWNER and GROUP the root directory is left unowned.  Those
+//* fields are metadata: who may write to the filesystem is decided by
+//* OWNER() on the UFSD parmlib MOUNT statement.  Give OWNER here when
+//* the disk should carry the name of the userid it is handed to.
 //*
 //* Comments use slash-star and star-slash, and must not start in
 //* column 1 of an instream SYSIN -- that would end the input.

--- a/src/ufsfmt.c
+++ b/src/ufsfmt.c
@@ -175,8 +175,8 @@ static const char *help_text[] = {
 "BLKSIZE   512-8192, multiple 512   4096      Block size in bytes",
 "DDNAME    DD name                  DISKFILE  DD of dataset to format",
 "INODES    1.0-50.0                 10.0      Percent of blocks for inodes",
-"OWNER     1-8 characters           HERC01    Root directory owner",
-"GROUP     1-8 characters           ADMIN     Root directory group",
+"OWNER     1-8 characters           (none)    Root directory owner",
+"GROUP     1-8 characters           (none)    Root directory group",
 "FORCE     --                       off       Overwrite an existing UFS",
 "QUIET     --                       off       Suppress messages and report",
 "VERBOSE   --                       off       Extra per-phase messages",
@@ -197,6 +197,12 @@ static const char *help_text[] = {
 " ",
 "An existing UFS370 filesystem is not overwritten unless FORCE is",
 "given.  The dataset must be allocated DISP=OLD.",
+" ",
+"Without OWNER and GROUP the root directory is left unowned.  The",
+"fields are metadata: who may write to the filesystem is decided by",
+"OWNER() on the UFSD parmlib MOUNT statement, not by them.  Give",
+"OWNER here when you want the disk to carry the name of the userid",
+"it is being handed to.",
 " ",
 "Example",
 "//FORMAT   EXEC PGM=UFSFMT",
@@ -290,10 +296,14 @@ main(int argc, char **argv)
 
     (void)argv;
 
+    /* No owner and no group unless OWNER/GROUP say otherwise (#62):
+    ** a formatter has no way of knowing who a filesystem belongs to,
+    ** and a name invented here would be indistinguishable from one
+    ** the operator chose.  The memset leaves both empty, which UFSD
+    ** reads as unowned -- and access is decided by OWNER() on the
+    ** MOUNT statement either way, never by this field. */
     memset(&p, 0, sizeof(p));
     strcpy(p.ddname, "DISKFILE");
-    strcpy(p.owner,  "HERC01");
-    strcpy(p.group,  "ADMIN");
     p.blksize   = 4096U;
     p.inode_pct = 10.0;
 
@@ -326,7 +336,8 @@ main(int argc, char **argv)
     if (p.verbose) {
         msg("UFSFMT16I DDNAME=%s BLKSIZE=%u INODES=%.1f "
             "OWNER=%s GROUP=%s%s\n",
-            p.ddname, p.blksize, p.inode_pct, p.owner, p.group,
+            p.ddname, p.blksize, p.inode_pct,
+            ufsfmt_owner_text(p.owner), ufsfmt_owner_text(p.group),
             p.force ? " FORCE" : "");
         msg("UFSFMT19I PARAMETERS ACCEPTED\n");
     }
@@ -1219,7 +1230,8 @@ format_root(DCB *dcb, const UFSFMT_GEOM *g, mtime64_t now,
             UFSFMT_ROOT_INO, g->root_block);
 
     msg("UFSFMT71I Root directory created, owner=%s, group=%s, mode=0%o\n",
-        p->owner, p->group, UFSFMT_ROOT_MODE);
+        ufsfmt_owner_text(p->owner), ufsfmt_owner_text(p->group),
+        UFSFMT_ROOT_MODE);
 
     return 0;
 }
@@ -1281,7 +1293,9 @@ write_super(DCB *dcb, const UFSFMT_GEOM *g, char *buf)
 **
 ** The format summary, and the parmlib line that mounts what was just
 ** built.  OWNER() carries the owner the disk was formatted for, which
-** is the documented way of handing a disk to a userid.
+** is the documented way of handing a disk to a userid -- and is left
+** out of the suggestion entirely when the disk was formatted without
+** one, so the line stays copyable (#62).
 ** ============================================================ */
 static void
 report(const UFSFMT_PARMS *p, const UFSFMT_GEOM *g, const char *dsn)
@@ -1306,10 +1320,14 @@ report(const UFSFMT_PARMS *p, const UFSFMT_GEOM *g, const char *dsn)
            g->inode_blocks, g->inode_slots, g->total_freeinode);
     printf("UFSFMT85I   Data blocks . . . %-14u(%u free)\n",
            data_blocks, g->total_freeblock);
-    printf("UFSFMT86I   Root owner  . . . %s/%s\n", p->owner, p->group);
+    printf("UFSFMT86I   Root owner  . . . %s/%s\n",
+           ufsfmt_owner_text(p->owner), ufsfmt_owner_text(p->group));
     printf(" \n");
     printf("UFSFMT90I Add to your UFSD parmlib member:\n");
-    printf("UFSFMT91I   MOUNT    DSN(%s) PATH(/your/mount/point) "
-           "MODE(RW) OWNER(%s)\n",
-           dsn[0] ? dsn : "your.dataset.name", p->owner);
+    {
+        char stmt[128];
+
+        ufsfmt_mount_stmt(stmt, sizeof(stmt), dsn, p->owner);
+        printf("UFSFMT91I   %s\n", stmt);
+    }
 }

--- a/src/ufsfmtg.c
+++ b/src/ufsfmtg.c
@@ -1,8 +1,11 @@
 /* UFSFMTG.C - UFS370 format geometry
 **
-** The arithmetic half of UFSFMT (see src/ufsfmt.c).  Portable C: no
-** MVS headers, no I/O, no EBCDIC, no 64-bit time -- so `make test-host`
-** can run it natively (test/mvs/tstufsg.c).
+** The arithmetic half of UFSFMT (see src/ufsfmt.c), plus the two
+** report helpers that have to decide what an absent owner looks like
+** (#62).  Portable C: no MVS headers, no I/O, no 64-bit time -- so
+** `make test-host` can run it natively (test/mvs/tstufsg.c).  The
+** string work here never reaches a disk; every byte that does is
+** written by src/ufsfmt.c.
 **
 ** The layout produced here is byte-compatible with ufsd-utils
 ** (pkg/ufs/image.go, func Create), which is the reference
@@ -140,4 +143,57 @@ ufsfmt_geometry(UFSFMT_GEOM *g, unsigned total_blocks,
     g->nfreeinode = n;
 
     return UFSFMT_GEOM_OK;
+}
+
+/* ============================================================
+** ufsfmt_owner_text
+**
+** See include/ufsfmt.h.  A NULL owner is treated as an absent one
+** rather than refused: this is called from the report, and a report
+** is not the place to fault.
+** ============================================================ */
+const char *
+ufsfmt_owner_text(const char *owner)
+{
+    return (owner && owner[0]) ? owner : UFSFMT_UNOWNED;
+}
+
+/* Append what fits of s, keeping out NUL-terminated within outsz.
+** Built by hand rather than with snprintf: the statement is assembled
+** from a handful of literals, and this stays within C89 stdio, which
+** is what cc370 provides. */
+static void
+app(char *out, unsigned outsz, unsigned *len, const char *s)
+{
+    while (*s && *len + 1U < outsz)
+        out[(*len)++] = *s++;
+    out[*len] = '\0';
+}
+
+/* ============================================================
+** ufsfmt_mount_stmt
+**
+** See include/ufsfmt.h.  Truncation is silent by design: the caller
+** is a report line, and a statement cut short is visibly incomplete
+** to the operator reading it, while a buffer run past its end is not
+** visible at all.
+** ============================================================ */
+void
+ufsfmt_mount_stmt(char *out, unsigned outsz,
+                  const char *dsn, const char *owner)
+{
+    unsigned len = 0U;
+
+    if (!out || outsz == 0U) return;
+    out[0] = '\0';
+
+    app(out, outsz, &len, "MOUNT    DSN(");
+    app(out, outsz, &len, (dsn && dsn[0]) ? dsn : "your.dataset.name");
+    app(out, outsz, &len, ") PATH(/your/mount/point) MODE(RW)");
+
+    if (owner && owner[0]) {
+        app(out, outsz, &len, " OWNER(");
+        app(out, outsz, &len, owner);
+        app(out, outsz, &len, ")");
+    }
 }

--- a/test/mvs/tstufsg.c
+++ b/test/mvs/tstufsg.c
@@ -226,6 +226,69 @@ check_planning_table(void)
     }
 }
 
+/* ============================================================
+** check_owner_text
+**
+** How an absent owner is shown to the operator (#62).  Since the
+** format defaults leave owner and group empty, every report line that
+** prints them would otherwise print nothing at all -- a summary
+** reading "Root owner . . . /" tells the operator neither that the
+** field is empty nor that empty is a legitimate value.
+** ============================================================ */
+static void
+check_owner_text(void)
+{
+    CHECK(strcmp(ufsfmt_owner_text("HERC01"), "HERC01") == 0,
+          "owner text: a name is shown as it is");
+    CHECK(strcmp(ufsfmt_owner_text(""), UFSFMT_UNOWNED) == 0,
+          "owner text: an empty owner is named, not blank");
+    CHECK(strcmp(ufsfmt_owner_text(NULL), UFSFMT_UNOWNED) == 0,
+          "owner text: a null owner is named, not a fault");
+}
+
+/* ============================================================
+** check_mount_stmt
+**
+** The parmlib line the report suggests (#62).  With no owner the
+** OWNER keyword has to be left out entirely: `OWNER()` is a syntax
+** error to the parmlib parser, and an operator copying the suggested
+** line has no reason to doubt it.  A mount without OWNER is also the
+** honest translation of an unowned filesystem -- any authenticated
+** user may write to it.
+** ============================================================ */
+static void
+check_mount_stmt(void)
+{
+    char buf[128];
+    char small[24];
+
+    ufsfmt_mount_stmt(buf, sizeof(buf), "MIKEG1.UFSHOME", "MIKEG1");
+    CHECK(strstr(buf, "DSN(MIKEG1.UFSHOME)") != NULL,
+          "mount stmt: carries the dataset");
+    CHECK(strstr(buf, "OWNER(MIKEG1)") != NULL,
+          "mount stmt: carries the owner when there is one");
+
+    ufsfmt_mount_stmt(buf, sizeof(buf), "MIKEG1.UFSHOME", "");
+    CHECK(strstr(buf, "OWNER") == NULL,
+          "mount stmt: no OWNER keyword when unowned");
+    CHECK(strstr(buf, "MODE(RW)") != NULL,
+          "mount stmt: still a complete statement when unowned");
+
+    ufsfmt_mount_stmt(buf, sizeof(buf), "", "MIKEG1");
+    CHECK(strstr(buf, "DSN(") != NULL,
+          "mount stmt: a missing dataset leaves a placeholder");
+
+    /* The report builds this into a fixed buffer, so a long dataset
+    ** name must truncate rather than run past its end. */
+    memset(small, '#', sizeof(small));
+    ufsfmt_mount_stmt(small, sizeof(small) - 1U,
+                      "VERY.LONG.DATASET.NAME.INDEED", "MIKEG1");
+    CHECK(strlen(small) < sizeof(small) - 1U,
+          "mount stmt: truncates inside the buffer");
+    CHECK(small[sizeof(small) - 1U] == '#',
+          "mount stmt: writes no byte past the size given");
+}
+
 int
 main(void)
 {
@@ -269,6 +332,8 @@ main(void)
     check_caches();
     check_rejects();
     check_planning_table();
+    check_owner_text();
+    check_mount_stmt();
 
     return mbt_test_summary("TSTUFSG");
 }


### PR DESCRIPTION
Closes #62. The ufsd-utils half is mvslovers/ufsd-utils#17 — the two formatters
write the same on-disk format and should not disagree about what an unspecified
owner means.

## What changes

UFSFMT leaves `owner` and `group` empty unless `OWNER`/`GROUP` say otherwise,
instead of writing `HERC01`/`ADMIN`. A formatter cannot know who a filesystem
belongs to, and a name invented at format time is indistinguishable from one the
operator chose. #61 removed the last obstacle: `mkdir_p` used to stamp
`UFSD`/`SYS1` onto any directory with an empty owner on every startup, so an
empty owner could not survive.

Access control is untouched. Who may write to a mounted filesystem is decided by
`OWNER()` on the parmlib `MOUNT` statement and by nothing else — the inode fields
are metadata that no permission check reads.

**Two report paths assumed a name was always there.** The summary would have
printed `Root owner . . . /`, and the suggested parmlib line would have carried
`OWNER()` with nothing inside it — a syntax error, in the one line whose entire
purpose is to be copied into a parmlib member. The summary now prints `(none)`,
and the `MOUNT` suggestion omits the keyword entirely, which is also the honest
translation of an unowned filesystem: any authenticated user may write to it.

Both decisions live in `ufsfmtg.c` next to the geometry, so `make test-host`
covers them.

## Red/green

**Host — `TSTUFSG` (extended).** Five new assertions over `ufsfmt_owner_text()`
and `ufsfmt_mount_stmt()`. They were written against the previous behaviour
first — the helpers initially reproduced today's output — and failed on it:

```
FAIL: owner text: an empty owner is named, not blank
FAIL: owner text: a null owner is named, not a fault
FAIL: mount stmt: no OWNER keyword when unowned
FAIL: mount stmt: truncates inside the buffer
FAIL: mount stmt: writes no byte past the size given
```

The last two are not incidental: the old line was built with an unbounded
`sprintf`, so moving it into a caller-supplied buffer had to be bounded.
Suite after: 180 PASS / 0 FAIL.

**MVS — end to end.** `IBMUSER.UFS62.TEST`, 64 blocks, formatted with only
`BLKSIZE` given:

```
UFSFMT16I DDNAME=DISKFILE BLKSIZE=4096 INODES=10.0 OWNER=(none) GROUP=(none)
UFSFMT71I Root directory created, owner=(none), group=(none), mode=0755
UFSFMT86I   Root owner  . . . (none)/(none)
UFSFMT91I   MOUNT    DSN(IBMUSER.UFS62.TEST) PATH(/your/mount/point) MODE(RW)
```

The dataset was then downloaded in binary and read directly rather than trusting
the report: root inode (inode 2, offset 0x20) carries `00` in all 18 bytes of
`owner` and `group`, with `mode=41ED`, `nlink=2` and a root directory block
holding `.` and `..`. The scratch dataset was deleted afterwards.

## Not changed

The byte comparison from #50 is unaffected: its procedure passes `OWNER`/`GROUP`
explicitly on both sides rather than relying on defaults ("Owner/group are *not*
masked: pass them explicitly and identically on both sides"). #62 said otherwise
when it was filed; that was wrong, and the issue has been corrected.
